### PR TITLE
Test infra: marker-gate notebooks, vision unit tests, tag-triggered release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,8 @@ name: Publish to PyPI
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "pyproject.toml"
+    tags:
+      - "v*"
 
 jobs:
   publish:
@@ -12,6 +11,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # Required for trusted publishing
+      contents: write  # Required for creating GitHub Releases
 
     steps:
       - uses: actions/checkout@v4
@@ -19,5 +19,19 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Verify tag matches pyproject version
+        run: |
+          tag_version="${GITHUB_REF#refs/tags/v}"
+          pyproject_version=$(uv version --short)
+          if [ "$tag_version" != "$pyproject_version" ]; then
+            echo "::error::Tag v${tag_version} does not match pyproject version ${pyproject_version}"
+            exit 1
+          fi
+
       - name: Build and publish
-        run: uv build && uv publish --check-url https://pypi.org/simple/bridge-ds/
+        run: uv build && uv publish
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,6 +52,14 @@ jobs:
 
         echo "Running: $cmd"
         eval $cmd
+    - name: Cache downloaded notebook test data
+      if: matrix.dependencies.test_dir == 'vision'
+      uses: actions/cache@v4
+      with:
+        path: |
+          /tmp/bridge-ds/tutorials/coco
+          /tmp/bridge-ds/tutorials/imdb
+        key: notebook-data-v1
     - name: Test with pytest
       run: |
         uv run pytest tests/${{ matrix.dependencies.test_dir }} -m "slow or not slow"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,4 +54,4 @@ jobs:
         eval $cmd
     - name: Test with pytest
       run: |
-        uv run pytest tests/${{ matrix.dependencies.test_dir }}
+        uv run pytest tests/${{ matrix.dependencies.test_dir }} -m "slow or not slow"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ $ cd bridge-ds
 $ uv sync --all-extras
 
 # Testing
-$ pytest tests/core
+# Default: fast unit tests across core + vision (notebooks excluded)
+$ pytest
+
+# Run notebook integration tests (slow, ~5 min, requires `vision` extras)
+$ pytest -m slow
+
+# Run everything (CI uses this)
+$ pytest -m "slow or not slow"
 
 # Building the docs
 $ sudo apt install pandoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,9 @@ dev = [
 [tool.uv.build-backend]
 module-name = "bridge"
 module-root = "."
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: opt-in slow tests (notebook integration); run with `pytest -m slow` or `pytest -m 'slow or not slow'`",
+]
+addopts = "-m 'not slow'"

--- a/tests/vision/conftest.py
+++ b/tests/vision/conftest.py
@@ -1,0 +1,84 @@
+"""Shared fixtures for vision tests.
+
+Uses synthetic in-memory data so unit tests run without network or large downloads.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bridge.primitives.dataset import SingularDataset
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.element import Element
+from bridge.utils.data_objects import BoundingBox, ClassLabel
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _holoviews_bokeh_backend():
+    """Panel display engine asserts the holoviews backend is bokeh; notebooks
+    set this via hv.extension('bokeh'). Match that here so tests don't need
+    to repeat the dance."""
+    import holoviews as hv
+
+    hv.extension("bokeh")
+
+
+@pytest.fixture
+def synthetic_image() -> np.ndarray:
+    return np.random.randint(0, 255, size=(64, 64, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def synthetic_classification_dataset(synthetic_image) -> SingularDataset:
+    """Two-sample image classification dataset, fully in-memory."""
+    images = []
+    labels = []
+    for i in range(2):
+        images.append(
+            Element(
+                element_id=f"img_{i}",
+                sample_id=i,
+                etype="image",
+                load_mechanism=LoadMechanism(synthetic_image.copy(), category="image"),
+            )
+        )
+        labels.append(
+            Element(
+                element_id=f"lbl_{i}",
+                sample_id=i,
+                etype="class_label",
+                load_mechanism=LoadMechanism(ClassLabel(class_idx=i, class_name=f"class_{i}"), category="obj"),
+            )
+        )
+    return SingularDataset.from_lists(images, labels)
+
+
+@pytest.fixture
+def synthetic_detection_dataset(synthetic_image) -> SingularDataset:
+    """Two-sample detection dataset with bboxes, fully in-memory."""
+    images = []
+    bboxes = []
+    for i in range(2):
+        images.append(
+            Element(
+                element_id=f"img_{i}",
+                sample_id=i,
+                etype="image",
+                load_mechanism=LoadMechanism(synthetic_image.copy(), category="image"),
+            )
+        )
+        for j in range(2):
+            bbox = BoundingBox(
+                coords=np.array([j * 10.0, j * 10.0, (j + 1) * 20.0, (j + 1) * 20.0]),
+                class_label=ClassLabel(class_idx=j, class_name=f"class_{j}"),
+            )
+            bboxes.append(
+                Element(
+                    element_id=f"bbox_{i}_{j}",
+                    sample_id=i,
+                    etype="bbox",
+                    load_mechanism=LoadMechanism(bbox, category="obj"),
+                )
+            )
+    return SingularDataset.from_lists(images, bboxes)

--- a/tests/vision/test_display.py
+++ b/tests/vision/test_display.py
@@ -1,0 +1,87 @@
+"""Unit tests for vision DisplayEngines.
+
+Exercises show_element / show_sample / show_dataset on tiny synthetic datasets.
+We assert that calls return non-None outputs of plausible types; we do not render.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bridge.display.basic import SimplePrints
+from bridge.display.vision import Panel
+
+
+@pytest.fixture
+def panel_engine() -> Panel:
+    return Panel(bbox_format="xyxy")
+
+
+@pytest.fixture
+def panel_engine_xywh() -> Panel:
+    return Panel(bbox_format="xywh")
+
+
+def test_panel_show_element_image(panel_engine, synthetic_classification_dataset):
+    sample = synthetic_classification_dataset.iget(0)
+    out = panel_engine.show_element(sample.element)
+    assert out is not None
+
+
+def test_panel_show_element_bbox(panel_engine, synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    bbox_element = sample.annotations["bbox"][0]
+    out = panel_engine.show_element(bbox_element)
+    assert out is not None
+
+
+def test_panel_show_element_unknown_etype_raises(panel_engine, synthetic_classification_dataset):
+    sample = synthetic_classification_dataset.iget(0)
+    label_element = sample.annotations["class_label"][0]
+    with pytest.raises(NotImplementedError):
+        panel_engine.show_element(label_element)
+
+
+def test_panel_show_sample_classification(panel_engine, synthetic_classification_dataset):
+    sample = synthetic_classification_dataset.iget(0)
+    out = panel_engine.show_sample(sample)
+    assert out is not None
+
+
+def test_panel_show_sample_detection(panel_engine, synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    out = panel_engine.show_sample(sample)
+    assert out is not None
+
+
+def test_panel_show_dataset(panel_engine, synthetic_detection_dataset):
+    out = panel_engine.show_dataset(synthetic_detection_dataset)
+    assert out is not None
+
+
+def test_panel_xywh_format_does_not_raise(panel_engine_xywh, synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    out = panel_engine_xywh.show_sample(sample)
+    assert out is not None
+
+
+def test_simple_prints_show_element(synthetic_classification_dataset, capsys):
+    engine = SimplePrints()
+    sample = synthetic_classification_dataset.iget(0)
+    engine.show_element(sample.element)
+    captured = capsys.readouterr()
+    assert sample.element.id in captured.out or str(sample.element.id) in captured.out
+
+
+def test_simple_prints_show_sample(synthetic_classification_dataset, capsys):
+    engine = SimplePrints()
+    engine.show_sample(synthetic_classification_dataset.iget(0))
+    captured = capsys.readouterr()
+    assert "Sample ID" in captured.out
+
+
+def test_simple_prints_show_dataset(synthetic_detection_dataset, capsys):
+    engine = SimplePrints()
+    engine.show_dataset(synthetic_detection_dataset)
+    captured = capsys.readouterr()
+    assert "Sample ID" in captured.out

--- a/tests/vision/test_notebooks.py
+++ b/tests/vision/test_notebooks.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 NOTEBOOK_DIR = Path.cwd() / "docs" / "source" / "user_guide" / "notebooks"
-NOTEBOOKS_LIST = [p for p in NOTEBOOK_DIR.rglob("*[!\.ipynb_checkpoints]*.ipynb") if ".ipynb_checkpoints" not in str(p)]
+NOTEBOOKS_LIST = [p for p in NOTEBOOK_DIR.rglob("*.ipynb") if ".ipynb_checkpoints" not in str(p)]
 
 
 @pytest.fixture(
@@ -17,6 +19,5 @@ def tb(request):
         yield tb
 
 
-# @pytest.mark.skip(reason="This test needs to be moved to the correct location")
 def test_notebook(tb):
     tb.execute()

--- a/tests/vision/test_providers.py
+++ b/tests/vision/test_providers.py
@@ -1,0 +1,113 @@
+"""Unit tests for DatasetProviders that operate on local data.
+
+Skips providers requiring real downloads (Coco, IMDb in download mode, CIFAR).
+Uses tmp_path to fabricate a tiny on-disk dataset matching each provider's
+expected directory layout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from bridge.providers.text import LargeMovieReviewDataset
+from bridge.providers.vision import ImageFolder
+
+
+def _write_jpeg(path: Path, h: int = 32, w: int = 32) -> None:
+    arr = np.random.randint(0, 255, size=(h, w, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(path, format="JPEG")
+
+
+@pytest.fixture
+def imagefolder_root(tmp_path) -> Path:
+    """Build a 2-class ImageFolder layout with 3 images per class."""
+    for class_name in ("cat", "dog"):
+        class_dir = tmp_path / class_name
+        class_dir.mkdir()
+        for i in range(3):
+            _write_jpeg(class_dir / f"{i}.jpg")
+    return tmp_path
+
+
+@pytest.fixture
+def imdb_root(tmp_path) -> Path:
+    """Build a tiny IMDb-like layout: aclImdb/train/{pos,neg}/*.txt.
+
+    Real IMDb filenames are <id>_<rating>.txt with disjoint ratings across
+    classes (1-4 neg, 7-10 pos) so stems never collide. Mirror that: use
+    different id ranges per class.
+    """
+    train = tmp_path / "aclImdb" / "train"
+    for class_name, base in (("neg", 0), ("pos", 100)):
+        d = train / class_name
+        d.mkdir(parents=True)
+        for i in range(3):
+            (d / f"{base + i}_1.txt").write_text(f"sample review {i} for {class_name}")
+    return tmp_path
+
+
+def test_imagefolder_builds_dataset(imagefolder_root):
+    provider = ImageFolder(imagefolder_root)
+    ds = provider.build_dataset()
+    assert len(ds) == 6  # 2 classes × 3 images
+
+
+def test_imagefolder_has_image_and_label_per_sample(imagefolder_root):
+    provider = ImageFolder(imagefolder_root)
+    ds = provider.build_dataset()
+
+    for sample in ds:
+        assert sample.element.etype == "image"
+        assert "class_label" in sample.annotations
+        assert len(sample.annotations["class_label"]) == 1
+
+
+def test_imagefolder_class_labels_distinct(imagefolder_root):
+    provider = ImageFolder(imagefolder_root)
+    ds = provider.build_dataset()
+
+    class_indices = set()
+    for sample in ds:
+        cl = sample.annotations["class_label"][0].data
+        class_indices.add(cl.class_idx)
+
+    assert class_indices == {0, 1}
+
+
+def test_imagefolder_image_data_loadable(imagefolder_root):
+    provider = ImageFolder(imagefolder_root)
+    ds = provider.build_dataset()
+
+    sample = ds.iget(0)
+    img = sample.element.data
+    assert img.shape == (32, 32, 3)
+    assert img.dtype == np.uint8
+
+
+def test_imdb_provider_builds_dataset(imdb_root):
+    provider = LargeMovieReviewDataset(root=imdb_root, split="train", download=False)
+    ds = provider.build_dataset()
+    assert len(ds) == 6  # 2 classes × 3 reviews
+
+
+def test_imdb_provider_has_text_and_label(imdb_root):
+    provider = LargeMovieReviewDataset(root=imdb_root, split="train", download=False)
+    ds = provider.build_dataset()
+
+    for sample in ds:
+        assert sample.element.etype == "text"
+        assert "class_label" in sample.annotations
+
+
+def test_imdb_provider_text_loadable(imdb_root):
+    provider = LargeMovieReviewDataset(root=imdb_root, split="train", download=False)
+    ds = provider.build_dataset()
+
+    sample = ds.iget(0)
+    text = sample.element.data
+    assert isinstance(text, str)
+    assert "sample review" in text

--- a/tests/vision/test_pytorch_engine.py
+++ b/tests/vision/test_pytorch_engine.py
@@ -1,0 +1,64 @@
+"""Unit tests for the PyTorch DataLoader bridge."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from bridge.engines.pytorch import PytorchEngineDataset
+
+
+def test_pytorch_dataset_len_matches_source(synthetic_classification_dataset):
+    pyt = PytorchEngineDataset(synthetic_classification_dataset)
+    assert len(pyt) == len(synthetic_classification_dataset)
+
+
+def test_pytorch_dataset_getitem_returns_dict_keyed_by_etype(synthetic_classification_dataset):
+    pyt = PytorchEngineDataset(synthetic_classification_dataset)
+    item = pyt[0]
+    assert isinstance(item, dict)
+    assert "image" in item
+    assert "class_label" in item
+
+
+def test_pytorch_dataset_image_data_is_array(synthetic_classification_dataset):
+    pyt = PytorchEngineDataset(synthetic_classification_dataset)
+    item = pyt[0]
+    assert isinstance(item["image"], list)
+    assert len(item["image"]) == 1
+    img = item["image"][0]
+    assert isinstance(img, np.ndarray)
+    assert img.shape == (64, 64, 3)
+
+
+def test_pytorch_dataset_iteration(synthetic_classification_dataset):
+    pyt = PytorchEngineDataset(synthetic_classification_dataset)
+    items = [pyt[i] for i in range(len(pyt))]
+    assert len(items) == 2
+    assert all("image" in it and "class_label" in it for it in items)
+
+
+def test_pytorch_dataset_with_torch_dataloader(synthetic_classification_dataset):
+    """End-to-end: wraps in torch.utils.data.DataLoader without crashing.
+
+    We use batch_size=1 and a no-op collate to avoid stacking issues from
+    the dict-of-lists shape.
+    """
+    from torch.utils.data import DataLoader
+
+    pyt = PytorchEngineDataset(synthetic_classification_dataset)
+    loader = DataLoader(pyt, batch_size=1, collate_fn=lambda batch: batch)
+    batches = list(loader)
+    assert len(batches) == 2
+    assert isinstance(batches[0], list)
+    assert "image" in batches[0][0]
+
+
+def test_pytorch_dataset_detection_shape(synthetic_detection_dataset):
+    pyt = PytorchEngineDataset(synthetic_detection_dataset)
+    item = pyt[0]
+    assert "image" in item
+    assert "bbox" in item
+    assert len(item["bbox"]) == 2  # two bboxes per sample in fixture

--- a/tests/vision/test_transforms.py
+++ b/tests/vision/test_transforms.py
@@ -1,0 +1,96 @@
+"""Unit tests for vision SampleTransforms."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+v2 = pytest.importorskip("torchvision.transforms.v2")
+
+from bridge.primitives.sample.transform.vision import TorchvisionV2Transform
+
+
+def test_horizontal_flip_preserves_image_shape(synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    original_shape = sample.element.data.shape
+
+    transform = TorchvisionV2Transform([v2.RandomHorizontalFlip(p=1.0)], bbox_format="XYXY")
+    transformed = sample.transform(transform)
+
+    out = transformed.element.data
+    if isinstance(out, torch.Tensor):
+        # tensor format CHW
+        assert out.shape[-2:] == original_shape[:2]
+    else:
+        assert out.shape[:2] == original_shape[:2]
+
+
+def test_transform_preserves_bbox_count_for_geometric_only(synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    n_bboxes_before = len(sample.annotations["bbox"])
+
+    transform = TorchvisionV2Transform([v2.RandomHorizontalFlip(p=1.0)], bbox_format="XYXY")
+    transformed = sample.transform(transform)
+
+    assert len(transformed.elements["bbox"]) == n_bboxes_before
+
+
+def test_transform_returns_singular_sample(synthetic_detection_dataset):
+    """SingularSample.transform should return a SingularSample, not the base Sample."""
+    from bridge.primitives.sample.singular_sample import SingularSample
+
+    sample = synthetic_detection_dataset.iget(0)
+    transform = TorchvisionV2Transform([v2.RandomHorizontalFlip(p=1.0)], bbox_format="XYXY")
+    transformed = sample.transform(transform)
+
+    assert isinstance(transformed, SingularSample)
+
+
+def test_transform_raises_without_image(synthetic_classification_dataset, mocker):
+    sample = synthetic_classification_dataset.iget(0)
+    # SingularSample.elements always contains the image; simulate the bad case
+    # where image is missing by removing it from the dict.
+    mocker.patch.object(sample, "_elements", {})
+    transform = TorchvisionV2Transform([v2.Identity()])
+
+    with pytest.raises(ValueError, match="image"):
+        transform(sample, cache_mechanisms={}, display_engine=None)
+
+
+def test_transform_changes_category_to_torch(synthetic_detection_dataset):
+    """When ToImage + ToDtype are applied, output category should swap to 'torch'."""
+    sample = synthetic_detection_dataset.iget(0)
+    transform = TorchvisionV2Transform(
+        [v2.ToImage(), v2.ToDtype(torch.float32, scale=True)],
+        bbox_format="XYXY",
+    )
+    transformed = sample.transform(transform)
+    assert transformed.element.category == "torch"
+    assert isinstance(transformed.element.data, torch.Tensor)
+
+
+def test_transform_resize_changes_image_shape(synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    transform = TorchvisionV2Transform(
+        [v2.ToImage(), v2.Resize((32, 32))],
+        bbox_format="XYXY",
+    )
+    transformed = sample.transform(transform)
+    out = transformed.element.data
+    # tensor in CHW format
+    assert out.shape[-2:] == (32, 32)
+
+
+def test_chained_transforms(synthetic_detection_dataset):
+    sample = synthetic_detection_dataset.iget(0)
+    flip = TorchvisionV2Transform([v2.RandomHorizontalFlip(p=1.0)], bbox_format="XYXY")
+    resize = TorchvisionV2Transform(
+        [v2.ToImage(), v2.Resize((32, 32))],
+        bbox_format="XYXY",
+    )
+
+    flipped = sample.transform(flip)
+    resized = flipped.transform(resize)
+
+    assert resized.element.data.shape[-2:] == (32, 32)


### PR DESCRIPTION
## Summary

- Marker-gates the notebook tests (`pytestmark = pytest.mark.slow`) so default `pytest` runs in ~3s instead of ~5min. CI keeps full coverage via `pytest -m "slow or not slow"`. Run notebooks locally on demand with `pytest -m slow`.
- Adds 30 vision unit tests across `test_display.py`, `test_transforms.py`, `test_providers.py`, `test_pytorch_engine.py`, mined from the doc notebooks. Use synthetic in-memory fixtures; no downloads needed. Provides real coverage for layers that previously only had notebook smoke tests.
- Replaces the publish trigger from "push to main touching pyproject.toml" with "push of v* tags." Adds a sanity check that the tag matches `uv version --short`. Adds a step that creates a GitHub Release with auto-generated notes.
- Documents the new test conventions in the README.

After merge, the local feedback loop becomes 3s for the inner unit suite (was 0.5s for core only or ~5min for vision). Vision unit tests are now the foundation for the upcoming multi-role rewrite.

## Test plan

- [x] Default `pytest` runs in <3s, deselects 9 notebook tests
- [x] `pytest -m slow` runs only notebook tests
- [x] `pytest -m "slow or not slow"` runs everything (CI invocation)
- [x] All 30 new vision unit tests pass
- [x] All 47 existing core tests still pass
- [x] Verify CI runs the new invocation correctly
- [ ] Future verification: tag a release (`v0.1.2`) and confirm the publish workflow runs once tags are pushed