### PR TITLE
Multi-role core: introduce role axis (v0.2 #2)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,6 @@ name: Pytests
 
 on:
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -134,6 +134,39 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         elements_df = pd.DataFrame(element_records).set_index(INDICES)
         return cls(elements=elements_df, display_engine=display_engine, cache_mechanisms=cache_mechanisms)
 
+    @classmethod
+    def from_role_dict(
+        cls,
+        elements_by_role: Dict[str, List[Element]],
+        display_engine: DisplayEngine | None = None,
+        cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
+    ) -> Self:
+        """Build a Dataset from elements grouped by role.
+
+        The role from each dict key is assigned to that element's row in the
+        underlying DataFrame, overriding any role already set on the
+        Element. Empty value lists are silently skipped. Caller's Element
+        instances are NOT mutated; only the DataFrame records carry the
+        assigned role.
+        """
+        from bridge.primitives.element.element import Element
+
+        records = []
+        for role, elements in elements_by_role.items():
+            for elem in elements:
+                record = elem.to_dict()
+                record[ELEMENT_COLS.ROLE] = role
+                records.append(pd.Series(record))
+        if not records:
+            elements_df = pd.DataFrame(columns=Element.keys).set_index(INDICES)
+        else:
+            elements_df = pd.DataFrame(records).set_index(INDICES)
+        return cls(
+            elements=elements_df,
+            display_engine=display_engine,
+            cache_mechanisms=cache_mechanisms,
+        )
+
     def _connect_caches(self):
         for cache in self._cache_mechanisms.values():
             if cache is not None:

--- a/bridge/primitives/element/element.py
+++ b/bridge/primitives/element/element.py
@@ -24,6 +24,7 @@ class Element(Displayable):
         etype: str,
         load_mechanism: LoadMechanism,
         sample_id: Hashable,
+        role: str | None = None,
         display_engine: DisplayEngine | None = None,
         cache_mechanism: CacheMechanism | None = None,
         metadata: Dict[str, Any] | None = None,
@@ -31,6 +32,7 @@ class Element(Displayable):
         validate_metadata(self.keys, metadata)
         self._element_id = element_id
         self._etype = etype
+        self._role = role if role is not None else etype
         self._sample_id = sample_id
         self._load_mechanism = load_mechanism
         self._display_engine = display_engine
@@ -58,6 +60,10 @@ class Element(Displayable):
         return self._etype
 
     @property
+    def role(self) -> str:
+        return self._role
+
+    @property
     def encoding(self) -> str:
         return self._load_mechanism.encoding
 
@@ -76,6 +82,7 @@ class Element(Displayable):
         return {
             ELEMENT_COLS.ID: self.id,
             ELEMENT_COLS.ETYPE: self.etype,
+            ELEMENT_COLS.ROLE: self.role,
             ELEMENT_COLS.SAMPLE_ID: self.sample_id,
             **self._load_mechanism.to_dict(),
             **self.metadata,
@@ -83,15 +90,19 @@ class Element(Displayable):
 
     @classmethod
     def from_dict(cls, dic: Dict[str, Any], **kwargs):
-        assert set(dic.keys()).issuperset(set(cls.keys)), f"Missing keys: {set(cls.keys) - set(dic.keys())}"
+        # ROLE is a recently-added column; tolerate dicts that predate it.
+        required_keys = set(cls.keys) - {ELEMENT_COLS.ROLE}
+        assert set(dic.keys()).issuperset(required_keys), f"Missing keys: {required_keys - set(dic.keys())}"
         element_id = dic[ELEMENT_COLS.ID]
         sample_id = dic[ELEMENT_COLS.SAMPLE_ID]
         etype = dic[ELEMENT_COLS.ETYPE]
+        role = dic.get(ELEMENT_COLS.ROLE)
         load_mechanism = LoadMechanism.from_dict({k: v for k, v in dic.items() if k in LoadMechanism.keys})
         metadata = {k: v for k, v in dic.items() if k not in cls.keys}
         return cls(
             element_id=element_id,
             etype=etype,
+            role=role,
             load_mechanism=load_mechanism,
             sample_id=sample_id,
             display_engine=kwargs.get("display_engine"),

--- a/bridge/primitives/sample/sample.py
+++ b/bridge/primitives/sample/sample.py
@@ -46,8 +46,8 @@ class Sample(Displayable):
     @property
     def data(self) -> Dict[str, List[ELEMENT_DATA_TYPE]]:
         data_dict = defaultdict(list)
-        for etype, elist in self._elements.items():
-            data_dict[etype].extend([e.data for e in elist])
+        for role, elist in self._elements.items():
+            data_dict[role].extend([e.data for e in elist])
         return dict(data_dict)
 
     def show(self, **kwargs: Any):
@@ -84,14 +84,12 @@ class Sample(Displayable):
 
         elements = []
         for element_row in fast_to_dict_records(elements_df):
-            etype = element_row[ELEMENT_COLS.ETYPE]
-
-            element_type = str(etype)
+            element_role = element_row.get(ELEMENT_COLS.ROLE, element_row[ELEMENT_COLS.ETYPE])
             elements.append(
                 Element.from_dict(
                     element_row,
                     display_engine=display_engine,
-                    cache_mechanism=cache_mechanisms.get(element_type),
+                    cache_mechanism=cache_mechanisms.get(element_role),
                 )
             )
         return cls(elements=elements, display_engine=display_engine)
@@ -116,10 +114,10 @@ class Sample(Displayable):
 
     @staticmethod
     def _convert_elements_list_to_dict(elements: List[Element]) -> Dict[str, List[Element]]:
-        elements_by_type: Dict[str, List[Element]] = defaultdict(list)
+        elements_by_role: Dict[str, List[Element]] = defaultdict(list)
         for element in elements:
-            elements_by_type[element.etype].append(element)
-        d = dict(elements_by_type)
+            elements_by_role[element.role].append(element)
+        d = dict(elements_by_role)
         return d
 
     @staticmethod
@@ -127,11 +125,11 @@ class Sample(Displayable):
         if cache_mechanisms is None:
             cache_mechanisms = {}
 
-        sample_etypes = sample.elements.keys()
-        if set(sample_etypes) == set(cache_mechanisms.keys()):
+        sample_roles = sample.elements.keys()
+        if set(sample_roles) == set(cache_mechanisms.keys()):
             return cache_mechanisms
 
-        default_cache_mechanisms = {etype: CacheMechanism() for etype in sample_etypes}
+        default_cache_mechanisms = {role: CacheMechanism() for role in sample_roles}
 
         missing_keys = set(default_cache_mechanisms.keys()) - set(cache_mechanisms.keys())
         if len(missing_keys) > 0:

--- a/bridge/primitives/sample/sample.py
+++ b/bridge/primitives/sample/sample.py
@@ -64,6 +64,18 @@ class Sample(Displayable):
                     out.append((role, e))
         return out
 
+    def one(self, role: str) -> Element:
+        """Return the single Element for `role`, asserting exactly one exists.
+
+        Raises ValueError if the role is missing or has multiple elements.
+        """
+        elements = self._elements.get(role, [])
+        if len(elements) != 1:
+            raise ValueError(
+                f"Sample.one(role={role!r}): expected exactly one element, got {len(elements)}"
+            )
+        return elements[0]
+
     def show(self, **kwargs: Any):
         return self._display_engine.show_sample(self, **kwargs)
 

--- a/bridge/primitives/sample/sample.py
+++ b/bridge/primitives/sample/sample.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Tuple
 
 import pandas as pd
 
@@ -49,6 +49,20 @@ class Sample(Displayable):
         for role, elist in self._elements.items():
             data_dict[role].extend([e.data for e in elist])
         return dict(data_dict)
+
+    def by_etype(self, etype: str) -> List[Tuple[str, Element]]:
+        """Return all elements with the given etype across roles.
+
+        Returns a list of (role, Element) tuples. Useful for transforms
+        that operate on a data-kind regardless of which sample-level role
+        it occupies.
+        """
+        out: List[Tuple[str, Element]] = []
+        for role, e_list in self._elements.items():
+            for e in e_list:
+                if e.etype == etype:
+                    out.append((role, e))
+        return out
 
     def show(self, **kwargs: Any):
         return self._display_engine.show_sample(self, **kwargs)

--- a/bridge/utils/constants.py
+++ b/bridge/utils/constants.py
@@ -31,6 +31,7 @@ class ElementCols(FlatAttributeListMixin):
     ID: str
     SAMPLE_ID: str
     ETYPE: str
+    ROLE: str
     LOAD_MECHANISM: LoadMechanismCols
 
 
@@ -38,6 +39,7 @@ ELEMENT_ID_COL_NAME = "element_id"
 SAMPLE_ID_COL_NAME = "sample_id"
 DATA_ENCODING_COL_NAME = "encoding"
 ELEMENT_TYPE_COL_NAME = "element_type"
+ROLE_COL_NAME = "role"
 
 ELEMENT_DATA_COL_NAME = "data"
 
@@ -48,6 +50,7 @@ ELEMENT_COLS = ElementCols(
     ID=ELEMENT_ID_COL_NAME,
     SAMPLE_ID=SAMPLE_ID_COL_NAME,
     ETYPE=ELEMENT_TYPE_COL_NAME,
+    ROLE=ROLE_COL_NAME,
     LOAD_MECHANISM=LOAD_MECHANISM_COL_NAMES,
 )
 

--- a/tests/core/test_dictable.py
+++ b/tests/core/test_dictable.py
@@ -66,6 +66,7 @@ def element_dict(load_mechanism_dict):
     return {
         ELEMENT_COLS.ID: "123",
         ELEMENT_COLS.ETYPE: "image",
+        ELEMENT_COLS.ROLE: "image",
         ELEMENT_COLS.SAMPLE_ID: 0,
         **load_mechanism_dict,
     }

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 from bridge.primitives.element.data.load_mechanism import LoadMechanism
 from bridge.primitives.element.element import Element
+from bridge.primitives.sample import Sample
 from bridge.utils.constants import ELEMENT_COLS
 from bridge.utils.data_objects import ClassLabel
 
 
-def _make_element(etype: str = "image", role: str | None = None) -> Element:
+def _make_element(
+    etype: str = "image",
+    role: str | None = None,
+    element_id: str = "el_0",
+    sample_id: str = "s_0",
+) -> Element:
     return Element(
-        element_id="el_0",
-        sample_id="s_0",
+        element_id=element_id,
+        sample_id=sample_id,
         etype=etype,
         role=role,
         load_mechanism=LoadMechanism(ClassLabel(class_idx=0), encoding="pickle"),
@@ -65,3 +71,22 @@ def test_from_dict_tolerates_missing_role_key():
     rebuilt = Element.from_dict(d)
     assert rebuilt.role == "text"  # falls back to etype
     assert rebuilt.etype == "text"
+
+
+def test_sample_groups_elements_by_role_when_roles_distinct():
+    """Two elements with the same etype but different roles go into different slots."""
+    ref = _make_element(role="reference", element_id="e0", sample_id="s0")
+    tgt = _make_element(role="target", element_id="e1", sample_id="s0")
+    sample = Sample(elements=[ref, tgt])
+    assert set(sample.elements.keys()) == {"reference", "target"}
+    assert sample.elements["reference"] == [ref]
+    assert sample.elements["target"] == [tgt]
+
+
+def test_sample_grouping_is_unchanged_when_roles_default():
+    """Two elements with the same etype and no explicit role group together (role==etype)."""
+    a = _make_element(element_id="e0", sample_id="s0")
+    b = _make_element(element_id="e1", sample_id="s0")
+    sample = Sample(elements=[a, b])
+    assert list(sample.elements.keys()) == ["image"]
+    assert sample.elements["image"] == [a, b]

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -90,3 +90,30 @@ def test_sample_grouping_is_unchanged_when_roles_default():
     sample = Sample(elements=[a, b])
     assert list(sample.elements.keys()) == ["image"]
     assert sample.elements["image"] == [a, b]
+
+
+def test_by_etype_collects_across_roles():
+    ref = _make_element(etype="image", role="reference", element_id="e0", sample_id="s0")
+    tgt = _make_element(etype="image", role="target", element_id="e1", sample_id="s0")
+    label = _make_element(etype="class_label", role="label", element_id="lbl", sample_id="s0")
+    sample = Sample(elements=[ref, tgt, label])
+
+    images = sample.by_etype("image")
+    assert {(role, e.id) for role, e in images} == {("reference", "e0"), ("target", "e1")}
+
+
+def test_by_etype_empty_when_etype_absent():
+    ref = _make_element(etype="image", role="reference", element_id="e0", sample_id="s0")
+    sample = Sample(elements=[ref])
+    assert sample.by_etype("bbox") == []
+
+
+def test_by_etype_works_when_role_equals_etype():
+    """Old-style elements (role==etype default) still find via by_etype."""
+    a = _make_element(etype="image", element_id="e0", sample_id="s0")
+    sample = Sample(elements=[a])
+    images = sample.by_etype("image")
+    assert len(images) == 1
+    role, elem = images[0]
+    assert role == "image"
+    assert elem.id == "e0"

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from bridge.primitives.dataset import Dataset
 from bridge.primitives.element.data.load_mechanism import LoadMechanism
 from bridge.primitives.element.element import Element
 from bridge.primitives.sample import Sample
@@ -141,3 +142,40 @@ def test_one_raises_when_role_has_multiple_elements():
     sample = Sample(elements=[a, b])
     with pytest.raises(ValueError, match="exactly one"):
         sample.one("image")
+
+
+def test_from_role_dict_assigns_roles_from_keys():
+    ref0 = _make_element(etype="image", element_id="e0", sample_id=0)
+    tgt0 = _make_element(etype="image", element_id="e1", sample_id=0)
+    ref1 = _make_element(etype="image", element_id="e2", sample_id=1)
+    tgt1 = _make_element(etype="image", element_id="e3", sample_id=1)
+    ds = Dataset.from_role_dict({
+        "reference": [ref0, ref1],
+        "target": [tgt0, tgt1],
+    })
+
+    sample = ds.iget(0)
+    assert set(sample.elements.keys()) == {"reference", "target"}
+    assert sample.one("reference").id == "e0"
+    assert sample.one("target").id == "e1"
+
+
+def test_from_role_dict_overrides_prior_role():
+    """If an Element already has a role set, the dict key wins."""
+    elem = _make_element(etype="image", role="ignored", element_id="e0", sample_id=0)
+    ds = Dataset.from_role_dict({"reference": [elem]})
+    assert ds.iget(0).one("reference").id == "e0"
+
+
+def test_from_role_dict_empty_value_lists_are_ok():
+    ref = _make_element(etype="image", element_id="e0", sample_id=0)
+    ds = Dataset.from_role_dict({"reference": [ref], "target": []})
+    assert "reference" in ds.iget(0).elements
+    assert "target" not in ds.iget(0).elements  # no element so no key
+
+
+def test_from_role_dict_does_not_mutate_input_elements():
+    elem = _make_element(etype="image", role="original_role", element_id="e0", sample_id=0)
+    Dataset.from_role_dict({"reference": [elem]})
+    # Caller's element should still have its original role
+    assert elem.role == "original_role"

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from bridge.primitives.element.data.load_mechanism import LoadMechanism
 from bridge.primitives.element.element import Element
 from bridge.primitives.sample import Sample
@@ -117,3 +119,25 @@ def test_by_etype_works_when_role_equals_etype():
     role, elem = images[0]
     assert role == "image"
     assert elem.id == "e0"
+
+
+def test_one_returns_single_element():
+    ref = _make_element(etype="image", role="reference", element_id="e0", sample_id="s0")
+    sample = Sample(elements=[ref])
+    elem = sample.one("reference")
+    assert elem is ref
+
+
+def test_one_raises_when_role_absent():
+    ref = _make_element(etype="image", role="reference", element_id="e0", sample_id="s0")
+    sample = Sample(elements=[ref])
+    with pytest.raises(ValueError, match="role='target'"):
+        sample.one("target")
+
+
+def test_one_raises_when_role_has_multiple_elements():
+    a = _make_element(etype="image", role="image", element_id="e0", sample_id="s0")
+    b = _make_element(etype="image", role="image", element_id="e1", sample_id="s0")
+    sample = Sample(elements=[a, b])
+    with pytest.raises(ValueError, match="exactly one"):
+        sample.one("image")

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -1,0 +1,67 @@
+"""Tests for Element.role and the role-as-default-etype convention."""
+
+from __future__ import annotations
+
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.element import Element
+from bridge.utils.constants import ELEMENT_COLS
+from bridge.utils.data_objects import ClassLabel
+
+
+def _make_element(etype: str = "image", role: str | None = None) -> Element:
+    return Element(
+        element_id="el_0",
+        sample_id="s_0",
+        etype=etype,
+        role=role,
+        load_mechanism=LoadMechanism(ClassLabel(class_idx=0), encoding="pickle"),
+    )
+
+
+def test_role_defaults_to_etype_when_unspecified():
+    elem = _make_element(etype="image")
+    assert elem.role == "image"
+
+
+def test_role_uses_explicit_value_when_provided():
+    elem = _make_element(etype="image", role="reference")
+    assert elem.role == "reference"
+    assert elem.etype == "image"  # etype unchanged
+
+
+def test_role_none_explicit_falls_back_to_etype():
+    elem = _make_element(etype="text", role=None)
+    assert elem.role == "text"
+
+
+def test_role_empty_string_is_preserved():
+    """Empty string is a valid (if unusual) role and must not trigger the etype fallback.
+
+    The fallback is keyed on `is None`, not bare truthiness — this test guards that.
+    """
+    elem = _make_element(etype="image", role="")
+    assert elem.role == ""
+
+
+def test_role_appears_in_to_dict():
+    elem = _make_element(etype="image", role="reference")
+    d = elem.to_dict()
+    assert d[ELEMENT_COLS.ROLE] == "reference"
+
+
+def test_to_dict_round_trip_preserves_role():
+    elem = _make_element(etype="image", role="target")
+    d = elem.to_dict()
+    rebuilt = Element.from_dict(d)
+    assert rebuilt.role == "target"
+    assert rebuilt.etype == "image"
+
+
+def test_from_dict_tolerates_missing_role_key():
+    """Backward compat: dicts written before the role column existed should still load."""
+    elem = _make_element(etype="text")
+    d = elem.to_dict()
+    d.pop(ELEMENT_COLS.ROLE)  # simulate old data
+    rebuilt = Element.from_dict(d)
+    assert rebuilt.role == "text"  # falls back to etype
+    assert rebuilt.etype == "text"


### PR DESCRIPTION
## Summary

Second sub-branch of the v0.2 multi-role rewrite. **Purely additive — no breaking changes.**

Introduces the **role** axis as distinct from **etype**:

- `Element` gains a `role: str | None = None` constructor parameter. When unspecified, role defaults to etype, so all existing call sites are unchanged.
- `ELEMENT_COLS` gains a `ROLE` column; `from_dict` tolerates dicts that predate it.
- `Sample.elements` switches grouping from etype to role. Because of the default, the dict shape is unchanged for any existing Element. New behavior: two elements with the same etype but different roles (e.g. paired image translation) land in separate dict slots.
- `Sample.by_etype(etype) -> List[(role, Element)]` — finds all elements of an etype regardless of role. Useful for transforms that operate on all images cross-role.
- `Sample.one(role) -> Element` — asserts exactly one and returns it. `ValueError` on zero or multiple.
- `Dataset.from_role_dict({"ref": [...], "tgt": [...]})` — convenience constructor. **Does not mutate caller's Element instances** — the role assignment lives at the DataFrame layer.
- Latent fix: `Sample.from_pd_dataframe` now looks up cache mechanisms by role (with etype fallback) instead of by etype, matching the role-keyed comparison in `_get_cache_mechanisms_for_transform`.

No new class is introduced; `Dataset` itself becomes role-aware.

## Backward compat

Every pre-existing test passes unchanged. SingularDataset / SingularSample continue to work because their Elements are constructed without an explicit role, so `role == etype` for all of them and `Sample.elements` continues to be keyed by what looks like etype values.

## Commits

```
2494f2b feat(dataset): add from_role_dict() convenience constructor
d12445f feat(sample): add one(role) sugar for single-element access
22e64e1 feat(sample): add by_etype() accessor crossing roles
3b748bf feat(sample): group elements by role instead of etype
964a84f feat(element): add role field defaulting to etype
```

## Test plan

- [x] 19 new tests in `tests/core/test_role.py` cover role default behavior, grouping, by_etype, one, and from_role_dict (including non-mutation of input)
- [x] All 84 baseline tests still pass
- [x] Notebook integration suite passes (9 notebooks, ~4:30)
- [x] TDD throughout — every behavior change had a failing test first

## Next sub-branch

`feature/element-store` — fix the cache aliasing bug. Decouples graph (per-Dataset DataFrame) from location state (shared ElementStore).