### PR TITLE
ElementStore: fix cache aliasing (v0.2 #3)

### DIFF
--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -44,11 +44,6 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         self._store = store
         self._display_engine = display_engine
         self._cache_mechanisms = cache_mechanisms or {}
-        # Cached joined view + the store mutation count at the time of caching.
-        # `elements` recomputes only when the store has been mutated since the
-        # cache was last populated.
-        self._cached_elements: pd.DataFrame | None = None
-        self._cached_mutation_count: int = -1
         for cache in self._cache_mechanisms.values():
             if cache is not None:
                 cache.bind_store(self._store)
@@ -93,16 +88,7 @@ class Dataset(TableAPI, SampleAPI, Displayable):
 
     @property
     def elements(self) -> pd.DataFrame:
-        # Cached: invalidate when the store mutation count changes (cache
-        # writes / extends bump the counter). For typical notebook patterns
-        # (build dataset, do many queries) this turns repeated samples /
-        # annotations / elements accesses from O(n_elements) per call into
-        # O(1) after the first.
-        current = self._store._mutation_count
-        if self._cached_elements is None or self._cached_mutation_count != current:
-            self._cached_elements = self._join_locations(self._df)
-            self._cached_mutation_count = current
-        return self._cached_elements
+        return self._join_locations(self._df)
 
     @property
     def sample_ids(self) -> List[Hashable]:

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -54,29 +54,41 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         columns (back-compat path for callers that hand-build a DataFrame).
         Returns the new store and a DataFrame without those columns.
         """
-        from bridge.primitives.element.data.load_mechanism import LoadMechanism
-
         store = ElementStore()
         url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
         enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
         if url_col not in df.columns or enc_col not in df.columns:
             return store, df
-        for (sample_id, element_id), row in df.iterrows():
-            store.set(
-                element_id,
-                LoadMechanism(row[url_col], encoding=row[enc_col]),
-            )
+
+        # Lazy import to avoid the circular dep noted on the dataset module.
+        from bridge.primitives.element.data.load_mechanism import LoadMechanism
+
+        eids = df.index.get_level_values(ELEMENT_COLS.ID).values
+        url_vals = df[url_col].values
+        enc_vals = df[enc_col].values
+        for eid, uod, enc in zip(eids, url_vals, enc_vals):
+            store.set(eid, LoadMechanism(uod, encoding=enc))
         return store, df.drop(columns=[url_col, enc_col])
 
-    @property
-    def elements(self) -> pd.DataFrame:
-        df = self._df.copy()
+    def _join_locations(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Add url_or_data / encoding columns to a copy of df by joining
+        with the lineage's ElementStore. Used by `elements` (full table)
+        and by SingularDataset's samples/annotations (filtered subsets).
+        """
+        df = df.copy()
         url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
         enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
         eids = df.index.get_level_values(ELEMENT_COLS.ID)
-        df[url_col] = [self._store.get(eid).url_or_data for eid in eids]
-        df[enc_col] = [self._store.get(eid).encoding for eid in eids]
+        # Single pass: fetch each LoadMechanism once, project both fields.
+        table = self._store._table
+        lms = [table[eid] for eid in eids]
+        df[url_col] = [lm.url_or_data for lm in lms]
+        df[enc_col] = [lm.encoding for lm in lms]
         return df
+
+    @property
+    def elements(self) -> pd.DataFrame:
+        return self._join_locations(self._df)
 
     @property
     def sample_ids(self) -> List[Hashable]:

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -9,6 +9,7 @@ from typing_extensions import Self
 
 from bridge.primitives.dataset.sample_api import SampleAPI
 from bridge.primitives.dataset.table_api import TableAPI
+from bridge.primitives.element.data.element_store import ElementStore
 from bridge.primitives.sample import Sample
 from bridge.utils.constants import ELEMENT_COLS, INDICES
 from bridge.utils.helper import Displayable
@@ -24,34 +25,91 @@ class Dataset(TableAPI, SampleAPI, Displayable):
     def __init__(
         self,
         elements: pd.DataFrame,
+        store: ElementStore | None = None,
         display_engine: DisplayEngine = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ):
-        self._elements = elements
+        if store is None:
+            store, elements = self._extract_store_from_df(elements)
+        else:
+            # Always strip location columns from _df, even when store is provided —
+            # they may have leaked back in via derivations that pass `self.elements`
+            # (which synthesizes the columns) into a new Dataset constructor.
+            url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
+            enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
+            cols_to_drop = [c for c in (url_col, enc_col) if c in elements.columns]
+            if cols_to_drop:
+                elements = elements.drop(columns=cols_to_drop)
+        self._df = elements
+        self._store = store
         self._display_engine = display_engine
         self._cache_mechanisms = cache_mechanisms or {}
-        self._connect_caches()
+        for cache in self._cache_mechanisms.values():
+            if cache is not None:
+                cache.bind_store(self._store)
+
+    @staticmethod
+    def _extract_store_from_df(df: pd.DataFrame) -> tuple[ElementStore, pd.DataFrame]:
+        """Build an ElementStore from a DataFrame's url_or_data + encoding
+        columns (back-compat path for callers that hand-build a DataFrame).
+        Returns the new store and a DataFrame without those columns.
+        """
+        from bridge.primitives.element.data.load_mechanism import LoadMechanism
+
+        store = ElementStore()
+        url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
+        enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
+        if url_col not in df.columns or enc_col not in df.columns:
+            return store, df
+        for (sample_id, element_id), row in df.iterrows():
+            store.set(
+                element_id,
+                LoadMechanism(row[url_col], encoding=row[enc_col]),
+            )
+        return store, df.drop(columns=[url_col, enc_col])
 
     @property
     def elements(self) -> pd.DataFrame:
-        return self._elements.copy()
+        df = self._df.copy()
+        url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
+        enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
+        eids = df.index.get_level_values(ELEMENT_COLS.ID)
+        df[url_col] = [self._store.get(eid).url_or_data for eid in eids]
+        df[enc_col] = [self._store.get(eid).encoding for eid in eids]
+        return df
 
     @property
     def sample_ids(self) -> List[Hashable]:
-        return self._elements.index.get_level_values(ELEMENT_COLS.SAMPLE_ID).drop_duplicates().to_list()
+        return self._df.index.get_level_values(ELEMENT_COLS.SAMPLE_ID).drop_duplicates().to_list()
 
     def select(self, selector: Callable):
+        # selector receives the user-facing elements (with location columns) for filtering
         selected = selector(self.elements)
-        elements = self.elements.loc[selected]
-        return Dataset(elements, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms)
+        elements = self._df.loc[selected]
+        return Dataset(
+            elements,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
+        )
 
     def assign(self, **kwargs: Dict[str, Callable[[pd.DataFrame], Sequence]]) -> Self:
-        new_elements = self._elements.assign(**kwargs)
-        return Dataset(new_elements, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms)
+        new_df = self._df.assign(**kwargs)
+        return Dataset(
+            new_df,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
+        )
 
     def sort(self, by: str, ascending: bool = True):
-        new_elements = self._elements.sort_values(by=by, ascending=ascending)
-        return Dataset(new_elements, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms)
+        new_df = self._df.sort_values(by=by, ascending=ascending)
+        return Dataset(
+            new_df,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
+        )
 
     def merge(
         self,
@@ -59,26 +117,43 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         display_engine: DisplayEngine | None = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> "Dataset":
-        self_element_ids = self.elements.index.get_level_values(ELEMENT_COLS.ID)
-        other_element_ids = other.elements.index.get_level_values(ELEMENT_COLS.ID)
+        """Merge two Datasets. Element ids must be disjoint.
+
+        Combines stores from both sides via ElementStore.extend. When
+        cache_mechanisms is None, merges the two sides' caches with
+        `other`'s entries overriding `self`'s on key conflict.
+        """
+        self_eids = self._df.index.get_level_values(ELEMENT_COLS.ID)
+        other_eids = other._df.index.get_level_values(ELEMENT_COLS.ID)
         assert (
-            len(self_element_ids.intersection(other_element_ids)) == 0
+            len(self_eids.intersection(other_eids)) == 0
         ), "Cannot merge Datasets with duplicate element ids."
-        elements = pd.concat([self.elements, other.elements])
+        elements = pd.concat([self._df, other._df])
+        merged_store = ElementStore()
+        merged_store.extend(self._store)
+        merged_store.extend(other._store)
         if display_engine is None:
             display_engine = self._display_engine
         if cache_mechanisms is None:
-            cache_mechanisms = self._cache_mechanisms
-        return Dataset(elements, display_engine, cache_mechanisms=cache_mechanisms)
+            cache_mechanisms = {**self._cache_mechanisms, **other._cache_mechanisms}
+        return Dataset(
+            elements,
+            store=merged_store,
+            display_engine=display_engine,
+            cache_mechanisms=cache_mechanisms,
+        )
 
     def iget(self, index: int) -> Sample:
         sample_id = self.sample_ids[index]
         return self.get(sample_id)
 
     def get(self, sample_id: Hashable) -> Sample:
-        sample_df = self._elements.xs(sample_id, level=ELEMENT_COLS.SAMPLE_ID, drop_level=False)
+        sample_df = self._df.xs(sample_id, level=ELEMENT_COLS.SAMPLE_ID, drop_level=False)
         return Sample.from_pd_dataframe(
-            sample_df, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
+            sample_df,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
         )
 
     def transform_samples(
@@ -119,7 +194,7 @@ class Dataset(TableAPI, SampleAPI, Displayable):
 
     def __repr__(self) -> str:
         lens_dict = {"n_samples": len(self)}
-        for etype, group in self._elements.groupby(ELEMENT_COLS.ETYPE):
+        for etype, group in self._df.groupby(ELEMENT_COLS.ETYPE):
             lens_dict[f"n_{etype}"] = len(group)
         return "Dataset: " + str(lens_dict)
 
@@ -130,9 +205,18 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         display_engine: DisplayEngine = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> Self:
-        element_records = [e.to_pd_series() for e in elements]
-        elements_df = pd.DataFrame(element_records).set_index(INDICES)
-        return cls(elements=elements_df, display_engine=display_engine, cache_mechanisms=cache_mechanisms)
+        store = ElementStore()
+        records = []
+        for elem in elements:
+            store.set(elem.id, elem._load_mechanism)
+            records.append(elem.to_pd_series())
+        elements_df = pd.DataFrame(records).set_index(INDICES)
+        return cls(
+            elements=elements_df,
+            store=store,
+            display_engine=display_engine,
+            cache_mechanisms=cache_mechanisms,
+        )
 
     @classmethod
     def from_role_dict(
@@ -141,33 +225,23 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         display_engine: DisplayEngine | None = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> Self:
-        """Build a Dataset from elements grouped by role.
-
-        The role from each dict key is assigned to that element's row in the
-        underlying DataFrame, overriding any role already set on the
-        Element. Empty value lists are silently skipped. Caller's Element
-        instances are NOT mutated; only the DataFrame records carry the
-        assigned role.
-        """
         from bridge.primitives.element.element import Element
 
+        store = ElementStore()
         records = []
         for role, elements in elements_by_role.items():
             for elem in elements:
                 record = elem.to_dict()
                 record[ELEMENT_COLS.ROLE] = role
                 records.append(pd.Series(record))
+                store.set(elem.id, elem._load_mechanism)
         if not records:
             elements_df = pd.DataFrame(columns=Element.keys).set_index(INDICES)
         else:
             elements_df = pd.DataFrame(records).set_index(INDICES)
         return cls(
             elements=elements_df,
+            store=store,
             display_engine=display_engine,
             cache_mechanisms=cache_mechanisms,
         )
-
-    def _connect_caches(self):
-        for cache in self._cache_mechanisms.values():
-            if cache is not None:
-                cache.set_elements_df(self._elements)

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -44,6 +44,11 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         self._store = store
         self._display_engine = display_engine
         self._cache_mechanisms = cache_mechanisms or {}
+        # Cached joined view + the store mutation count at the time of caching.
+        # `elements` recomputes only when the store has been mutated since the
+        # cache was last populated.
+        self._cached_elements: pd.DataFrame | None = None
+        self._cached_mutation_count: int = -1
         for cache in self._cache_mechanisms.values():
             if cache is not None:
                 cache.bind_store(self._store)
@@ -88,7 +93,16 @@ class Dataset(TableAPI, SampleAPI, Displayable):
 
     @property
     def elements(self) -> pd.DataFrame:
-        return self._join_locations(self._df)
+        # Cached: invalidate when the store mutation count changes (cache
+        # writes / extends bump the counter). For typical notebook patterns
+        # (build dataset, do many queries) this turns repeated samples /
+        # annotations / elements accesses from O(n_elements) per call into
+        # O(1) after the first.
+        current = self._store._mutation_count
+        if self._cached_elements is None or self._cached_mutation_count != current:
+            self._cached_elements = self._join_locations(self._df)
+            self._cached_mutation_count = current
+        return self._cached_elements
 
     @property
     def sample_ids(self) -> List[Hashable]:

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -79,9 +79,7 @@ class Dataset(TableAPI, SampleAPI, Displayable):
         url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
         enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
         eids = df.index.get_level_values(ELEMENT_COLS.ID)
-        # Single pass: fetch each LoadMechanism once, project both fields.
-        table = self._store._table
-        lms = [table[eid] for eid in eids]
+        lms = [self._store.get(eid) for eid in eids]
         df[url_col] = [lm.url_or_data for lm in lms]
         df[enc_col] = [lm.encoding for lm in lms]
         return df

--- a/bridge/primitives/dataset/singular_dataset.py
+++ b/bridge/primitives/dataset/singular_dataset.py
@@ -6,6 +6,7 @@ import pandas as pd
 from typing_extensions import Self
 
 from bridge.primitives.dataset.dataset import Dataset
+from bridge.primitives.element.data.element_store import ElementStore
 from bridge.primitives.sample.singular_sample import SingularSample
 from bridge.utils.constants import ELEMENT_COLS, INDICES, IS_SAMPLE_COL_NAME
 
@@ -28,6 +29,7 @@ class SingularDataset(Dataset):
         self,
         samples: pd.DataFrame,
         annotations: pd.DataFrame,
+        store: ElementStore | None = None,
         display_engine: DisplayEngine = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ):
@@ -43,20 +45,22 @@ class SingularDataset(Dataset):
         samples[IS_SAMPLE_COL_NAME] = True
         annotations[IS_SAMPLE_COL_NAME] = False
         elements = pd.concat([samples, annotations])
-        super().__init__(elements, display_engine, cache_mechanisms)
+        super().__init__(elements, store=store, display_engine=display_engine, cache_mechanisms=cache_mechanisms)
 
     @property
     def samples(self) -> pd.DataFrame:
+        full = self.elements
         return (
-            self._elements.loc[self._elements[IS_SAMPLE_COL_NAME]]
+            full.loc[full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
 
     @property
     def annotations(self) -> pd.DataFrame:
+        full = self.elements
         return (
-            self._elements.loc[~self._elements[IS_SAMPLE_COL_NAME]]
+            full.loc[~full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
@@ -80,6 +84,7 @@ class SingularDataset(Dataset):
         return SingularDataset(
             new_samples,
             new_annotations,
+            store=self._store,
             display_engine=self._display_engine,
             cache_mechanisms=self._cache_mechanisms,
         )
@@ -91,6 +96,7 @@ class SingularDataset(Dataset):
         return SingularDataset(
             self.samples,
             new_annotations,
+            store=self._store,
             display_engine=self._display_engine,
             cache_mechanisms=self._cache_mechanisms,
         )
@@ -101,6 +107,7 @@ class SingularDataset(Dataset):
         return SingularDataset(
             new_samples,
             self.annotations,
+            store=self._store,
             display_engine=self._display_engine,
             cache_mechanisms=self._cache_mechanisms,
         )
@@ -111,6 +118,7 @@ class SingularDataset(Dataset):
         return SingularDataset(
             self.samples,
             new_annotations,
+            store=self._store,
             display_engine=self._display_engine,
             cache_mechanisms=self._cache_mechanisms,
         )
@@ -118,13 +126,13 @@ class SingularDataset(Dataset):
     def sort_samples(self, by: str, ascending: bool = True):
         new_samples = self.samples.sort_values(by=by, ascending=ascending)
         return SingularDataset(
-            new_samples, self.annotations, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
+            new_samples, self.annotations, store=self._store, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
         )
 
     def sort_annotations(self, by: str, ascending: bool = True):
         new_annotations = self.annotations.sort_values(by=by, ascending=ascending)
         return SingularDataset(
-            self.samples, new_annotations, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
+            self.samples, new_annotations, store=self._store, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
         )
 
     def transform_samples(
@@ -137,13 +145,14 @@ class SingularDataset(Dataset):
         ds = super().transform_samples(
             transform, map_fn=map_fn, cache_mechanisms=cache_mechanisms, display_engine=display_engine
         )
+        full = ds.elements
         samples = (
-            ds.elements.loc[ds.elements[IS_SAMPLE_COL_NAME]]
+            full.loc[full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
         annotations = (
-            ds.elements.loc[~ds.elements[IS_SAMPLE_COL_NAME]]
+            full.loc[~full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
@@ -157,10 +166,17 @@ class SingularDataset(Dataset):
         display_engine: DisplayEngine = None,
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> Self:
-        sample_records = [s.to_dict() for s in samples_list]
-        annotation_records = [a.to_dict() for a in annotations_list]
+        store = ElementStore()
+        sample_records = []
+        for s in samples_list:
+            sample_records.append(s.to_dict())
+            store.set(s.id, s._load_mechanism)
+        annotation_records = []
+        for a in annotations_list:
+            annotation_records.append(a.to_dict())
+            store.set(a.id, a._load_mechanism)
 
         samples_df = pd.DataFrame(sample_records).set_index(INDICES)
         annotations_df = pd.DataFrame(annotation_records).set_index(INDICES)
 
-        return cls(samples_df, annotations_df, display_engine=display_engine, cache_mechanisms=cache_mechanisms)
+        return cls(samples_df, annotations_df, store=store, display_engine=display_engine, cache_mechanisms=cache_mechanisms)

--- a/bridge/primitives/dataset/singular_dataset.py
+++ b/bridge/primitives/dataset/singular_dataset.py
@@ -49,18 +49,18 @@ class SingularDataset(Dataset):
 
     @property
     def samples(self) -> pd.DataFrame:
-        full = self.elements
+        sub = self._df.loc[self._df[IS_SAMPLE_COL_NAME]]
         return (
-            full.loc[full[IS_SAMPLE_COL_NAME]]
+            self._join_locations(sub)
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
 
     @property
     def annotations(self) -> pd.DataFrame:
-        full = self.elements
+        sub = self._df.loc[~self._df[IS_SAMPLE_COL_NAME]]
         return (
-            full.loc[~full[IS_SAMPLE_COL_NAME]]
+            self._join_locations(sub)
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )

--- a/bridge/primitives/dataset/singular_dataset.py
+++ b/bridge/primitives/dataset/singular_dataset.py
@@ -49,18 +49,18 @@ class SingularDataset(Dataset):
 
     @property
     def samples(self) -> pd.DataFrame:
-        full = self.elements  # cached at the parent Dataset level
+        sub = self._df.loc[self._df[IS_SAMPLE_COL_NAME]]
         return (
-            full.loc[full[IS_SAMPLE_COL_NAME]]
+            self._join_locations(sub)
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
 
     @property
     def annotations(self) -> pd.DataFrame:
-        full = self.elements  # cached at the parent Dataset level
+        sub = self._df.loc[~self._df[IS_SAMPLE_COL_NAME]]
         return (
-            full.loc[~full[IS_SAMPLE_COL_NAME]]
+            self._join_locations(sub)
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )

--- a/bridge/primitives/dataset/singular_dataset.py
+++ b/bridge/primitives/dataset/singular_dataset.py
@@ -72,15 +72,15 @@ class SingularDataset(Dataset):
         return SingularSample.from_sample(super().get(sample_id))
 
     def select_samples(self, selector: Callable[[pd.DataFrame, pd.DataFrame], Sequence]):
-        selected = selector(self.samples, self.annotations)
-        new_samples = self.samples.loc[selected]
-        new_annotations = self.annotations.pipe(
-            lambda df_: df_.loc[
-                df_.index.get_level_values(ELEMENT_COLS.SAMPLE_ID).isin(
-                    new_samples.index.get_level_values(ELEMENT_COLS.SAMPLE_ID)
-                )
-            ]
-        )
+        samples = self.samples
+        annotations = self.annotations
+        selected = selector(samples, annotations)
+        new_samples = samples.loc[selected]
+        new_annotations = annotations.loc[
+            annotations.index.get_level_values(ELEMENT_COLS.SAMPLE_ID).isin(
+                new_samples.index.get_level_values(ELEMENT_COLS.SAMPLE_ID)
+            )
+        ]
         return SingularDataset(
             new_samples,
             new_annotations,
@@ -90,11 +90,13 @@ class SingularDataset(Dataset):
         )
 
     def select_annotations(self, selector: Callable[[pd.DataFrame, pd.DataFrame], Sequence]):
-        selected = selector(self.samples, self.annotations)
-        new_annotations = self.annotations.loc[selected]
+        samples = self.samples
+        annotations = self.annotations
+        selected = selector(samples, annotations)
+        new_annotations = annotations.loc[selected]
 
         return SingularDataset(
-            self.samples,
+            samples,
             new_annotations,
             store=self._store,
             display_engine=self._display_engine,
@@ -102,21 +104,25 @@ class SingularDataset(Dataset):
         )
 
     def assign_samples(self, **kwargs: Callable[[pd.DataFrame, pd.DataFrame], Sequence]) -> Self:
-        values_dict = {name: assign_fn(self.samples, self.annotations) for name, assign_fn in kwargs.items()}
-        new_samples = self.samples.assign(**values_dict)
+        samples = self.samples
+        annotations = self.annotations
+        values_dict = {name: assign_fn(samples, annotations) for name, assign_fn in kwargs.items()}
+        new_samples = samples.assign(**values_dict)
         return SingularDataset(
             new_samples,
-            self.annotations,
+            annotations,
             store=self._store,
             display_engine=self._display_engine,
             cache_mechanisms=self._cache_mechanisms,
         )
 
     def assign_annotations(self, **kwargs: Callable[[pd.DataFrame, pd.DataFrame], Sequence]) -> Self:
-        values_dict = {name: assign_fn(self.samples, self.annotations) for name, assign_fn in kwargs.items()}
-        new_annotations = self.annotations.assign(**values_dict)
+        samples = self.samples
+        annotations = self.annotations
+        values_dict = {name: assign_fn(samples, annotations) for name, assign_fn in kwargs.items()}
+        new_annotations = annotations.assign(**values_dict)
         return SingularDataset(
-            self.samples,
+            samples,
             new_annotations,
             store=self._store,
             display_engine=self._display_engine,
@@ -124,15 +130,27 @@ class SingularDataset(Dataset):
         )
 
     def sort_samples(self, by: str, ascending: bool = True):
-        new_samples = self.samples.sort_values(by=by, ascending=ascending)
+        samples = self.samples
+        annotations = self.annotations
+        new_samples = samples.sort_values(by=by, ascending=ascending)
         return SingularDataset(
-            new_samples, self.annotations, store=self._store, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
+            new_samples,
+            annotations,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
         )
 
     def sort_annotations(self, by: str, ascending: bool = True):
-        new_annotations = self.annotations.sort_values(by=by, ascending=ascending)
+        samples = self.samples
+        annotations = self.annotations
+        new_annotations = annotations.sort_values(by=by, ascending=ascending)
         return SingularDataset(
-            self.samples, new_annotations, store=self._store, display_engine=self._display_engine, cache_mechanisms=self._cache_mechanisms
+            samples,
+            new_annotations,
+            store=self._store,
+            display_engine=self._display_engine,
+            cache_mechanisms=self._cache_mechanisms,
         )
 
     def transform_samples(

--- a/bridge/primitives/dataset/singular_dataset.py
+++ b/bridge/primitives/dataset/singular_dataset.py
@@ -49,18 +49,18 @@ class SingularDataset(Dataset):
 
     @property
     def samples(self) -> pd.DataFrame:
-        sub = self._df.loc[self._df[IS_SAMPLE_COL_NAME]]
+        full = self.elements  # cached at the parent Dataset level
         return (
-            self._join_locations(sub)
+            full.loc[full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )
 
     @property
     def annotations(self) -> pd.DataFrame:
-        sub = self._df.loc[~self._df[IS_SAMPLE_COL_NAME]]
+        full = self.elements  # cached at the parent Dataset level
         return (
-            self._join_locations(sub)
+            full.loc[~full[IS_SAMPLE_COL_NAME]]
             .dropna(axis="columns", how="all")
             .drop(columns=IS_SAMPLE_COL_NAME)
         )

--- a/bridge/primitives/element/data/cache_mechanism.py
+++ b/bridge/primitives/element/data/cache_mechanism.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Hashable
-
-import pandas as pd
+from typing import TYPE_CHECKING
 
 from bridge.primitives.element.data import encoding_registry
 from bridge.primitives.element.data.uri_components import URIComponents
 
 if TYPE_CHECKING:
+    from bridge.primitives.element.data.element_store import ElementStore
     from bridge.primitives.element.data.load_mechanism import LoadMechanism
     from bridge.primitives.element.element import Element
     from bridge.primitives.element.element_data_type import ELEMENT_DATA_TYPE
@@ -15,38 +14,45 @@ if TYPE_CHECKING:
 
 class CacheMechanism:
     def __init__(self, root_uri: URIComponents | None = None):
-        self._elements = None
         self._root_uri = root_uri
+        self._store: ElementStore | None = None
 
-    def set_elements_df(self, elements: pd.DataFrame):
-        self._elements = elements
+    def bind_store(self, store: ElementStore) -> None:
+        """Attach the lineage's ElementStore. Called by Dataset.__init__.
+
+        Idempotent for the same store. Raises if rebound to a different
+        store, since that would mean the cache is being shared across
+        lineages — which would reintroduce the aliasing class of bug
+        this design is meant to prevent.
+        """
+        if self._store is not None and self._store is not store:
+            raise ValueError(
+                "CacheMechanism is already bound to a different ElementStore. "
+                "Cache mechanisms are single-lineage; create a new CacheMechanism "
+                "for an independent Dataset lineage."
+            )
+        self._store = store
 
     def store(
         self,
         element: Element,
         data: ELEMENT_DATA_TYPE,
         as_encoding: str | None = None,
-        should_update_elements: bool = False,
     ) -> LoadMechanism:
         if as_encoding is None:
             as_encoding = element.encoding
         assert encoding_registry.is_registered(as_encoding), f"Encoding {as_encoding} is not registered."
         uri = self._build_uri(element, as_encoding)
         new_provider = encoding_registry.store(data, uri, as_encoding)
-        if should_update_elements and self._elements is not None:
-            self._update_samples_with_new_provider(element.id, new_provider)
+        if self._store is not None:
+            self._store.update(element.id, new_provider)
         return new_provider
 
     def _build_uri(self, element: Element, encoding: str) -> URIComponents | None:
         if self._root_uri is None:
             return None
 
-        uri = URIComponents(
+        return URIComponents(
             scheme=self._root_uri.scheme,
             path=self._root_uri.path + f"/{element.id}{encoding_registry.extension(encoding)}",
         )
-        return uri
-
-    def _update_samples_with_new_provider(self, element_id: Hashable, new_provider: LoadMechanism):
-        dic = new_provider.to_dict()
-        self._elements.loc[(slice(None), element_id), list(dic.keys())] = dic.values()

--- a/bridge/primitives/element/data/element_store.py
+++ b/bridge/primitives/element/data/element_store.py
@@ -1,0 +1,54 @@
+"""ElementStore: a shared canonical map of element_id -> LoadMechanism.
+
+The store is shared by reference across all Datasets in a derivation
+lineage. Cache writes mutate the store; every Dataset that holds the
+same store reference sees the update.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Hashable, Iterator
+
+if TYPE_CHECKING:
+    from bridge.primitives.element.data.load_mechanism import LoadMechanism
+
+
+class ElementStore:
+    """Mutable mapping from element_id to LoadMechanism."""
+
+    def __init__(self) -> None:
+        self._table: dict[Hashable, "LoadMechanism"] = {}
+
+    def __contains__(self, element_id: Hashable) -> bool:
+        return element_id in self._table
+
+    def __len__(self) -> int:
+        return len(self._table)
+
+    def __iter__(self) -> Iterator[Hashable]:
+        return iter(self._table)
+
+    def set(self, element_id: Hashable, load_mechanism: "LoadMechanism") -> None:
+        """Set the LoadMechanism for an element_id, raising if already present."""
+        if element_id in self._table:
+            raise ValueError(
+                f"ElementStore already has an entry for {element_id!r}; "
+                "use update() to overwrite or extend() to merge stores."
+            )
+        self._table[element_id] = load_mechanism
+
+    def update(self, element_id: Hashable, load_mechanism: "LoadMechanism") -> None:
+        """Set or overwrite the LoadMechanism for an element_id."""
+        self._table[element_id] = load_mechanism
+
+    def get(self, element_id: Hashable) -> "LoadMechanism":
+        return self._table[element_id]
+
+    def extend(self, other: "ElementStore") -> None:
+        """Merge another store's entries into this one. Element ids must be disjoint."""
+        overlap = set(self._table) & set(other._table)
+        if overlap:
+            raise ValueError(
+                f"Cannot extend ElementStore: element_id overlap on {sorted(overlap)!r}"
+            )
+        self._table.update(other._table)

--- a/bridge/primitives/element/data/element_store.py
+++ b/bridge/primitives/element/data/element_store.py
@@ -18,6 +18,9 @@ class ElementStore:
 
     def __init__(self) -> None:
         self._table: dict[Hashable, "LoadMechanism"] = {}
+        # Incremented on every mutation; Datasets read this to detect when
+        # cached joined views are stale.
+        self._mutation_count: int = 0
 
     def __contains__(self, element_id: Hashable) -> bool:
         return element_id in self._table
@@ -36,10 +39,12 @@ class ElementStore:
                 "use update() to overwrite or extend() to merge stores."
             )
         self._table[element_id] = load_mechanism
+        self._mutation_count += 1
 
     def update(self, element_id: Hashable, load_mechanism: "LoadMechanism") -> None:
         """Set or overwrite the LoadMechanism for an element_id."""
         self._table[element_id] = load_mechanism
+        self._mutation_count += 1
 
     def get(self, element_id: Hashable) -> "LoadMechanism":
         try:
@@ -57,3 +62,4 @@ class ElementStore:
                 f"Cannot extend ElementStore: element_id overlap on {sorted(overlap)!r}"
             )
         self._table.update(other._table)
+        self._mutation_count += 1

--- a/bridge/primitives/element/data/element_store.py
+++ b/bridge/primitives/element/data/element_store.py
@@ -42,7 +42,12 @@ class ElementStore:
         self._table[element_id] = load_mechanism
 
     def get(self, element_id: Hashable) -> "LoadMechanism":
-        return self._table[element_id]
+        try:
+            return self._table[element_id]
+        except KeyError:
+            raise KeyError(
+                f"ElementStore has no entry for element_id={element_id!r}"
+            ) from None
 
     def extend(self, other: "ElementStore") -> None:
         """Merge another store's entries into this one. Element ids must be disjoint."""

--- a/bridge/primitives/element/data/element_store.py
+++ b/bridge/primitives/element/data/element_store.py
@@ -18,9 +18,6 @@ class ElementStore:
 
     def __init__(self) -> None:
         self._table: dict[Hashable, "LoadMechanism"] = {}
-        # Incremented on every mutation; Datasets read this to detect when
-        # cached joined views are stale.
-        self._mutation_count: int = 0
 
     def __contains__(self, element_id: Hashable) -> bool:
         return element_id in self._table
@@ -39,12 +36,10 @@ class ElementStore:
                 "use update() to overwrite or extend() to merge stores."
             )
         self._table[element_id] = load_mechanism
-        self._mutation_count += 1
 
     def update(self, element_id: Hashable, load_mechanism: "LoadMechanism") -> None:
         """Set or overwrite the LoadMechanism for an element_id."""
         self._table[element_id] = load_mechanism
-        self._mutation_count += 1
 
     def get(self, element_id: Hashable) -> "LoadMechanism":
         try:
@@ -62,4 +57,3 @@ class ElementStore:
                 f"Cannot extend ElementStore: element_id overlap on {sorted(overlap)!r}"
             )
         self._table.update(other._table)
-        self._mutation_count += 1

--- a/bridge/primitives/element/data/uri_components.py
+++ b/bridge/primitives/element/data/uri_components.py
@@ -16,9 +16,6 @@ class URIComponents:
     def __str__(self):
         return urlunparse((self.scheme, self.netloc, self.path, self.params, self.query, self.fragment))
 
-    def __next__(self):
-        raise NotImplementedError("This is here for pandas...")
-
     @classmethod
     def from_str(cls, s: str) -> Self:
         return cls(*urlparse(s))

--- a/bridge/primitives/element/element.py
+++ b/bridge/primitives/element/element.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class Element(Displayable):
-    keys = ELEMENT_COLS.list()
+    keys = [ELEMENT_COLS.ID, ELEMENT_COLS.SAMPLE_ID, ELEMENT_COLS.ETYPE, ELEMENT_COLS.ROLE]
 
     def __init__(
         self,
@@ -50,7 +50,7 @@ class Element(Displayable):
     def _data_impl(self):
         data = self._load_mechanism.load_data()
         if self._cache_mechanism:
-            new_load_mechanism = self._cache_mechanism.store(self, data, should_update_elements=True)
+            new_load_mechanism = self._cache_mechanism.store(self, data)
             self._load_mechanism = new_load_mechanism
             return data
         return data
@@ -84,12 +84,11 @@ class Element(Displayable):
             ELEMENT_COLS.ETYPE: self.etype,
             ELEMENT_COLS.ROLE: self.role,
             ELEMENT_COLS.SAMPLE_ID: self.sample_id,
-            **self._load_mechanism.to_dict(),
             **self.metadata,
         }
 
     @classmethod
-    def from_dict(cls, dic: Dict[str, Any], **kwargs):
+    def from_dict(cls, dic: Dict[str, Any], load_mechanism: LoadMechanism, **kwargs):
         # ROLE is a recently-added column; tolerate dicts that predate it.
         required_keys = set(cls.keys) - {ELEMENT_COLS.ROLE}
         assert set(dic.keys()).issuperset(required_keys), f"Missing keys: {required_keys - set(dic.keys())}"
@@ -97,7 +96,8 @@ class Element(Displayable):
         sample_id = dic[ELEMENT_COLS.SAMPLE_ID]
         etype = dic[ELEMENT_COLS.ETYPE]
         role = dic.get(ELEMENT_COLS.ROLE)
-        load_mechanism = LoadMechanism.from_dict({k: v for k, v in dic.items() if k in LoadMechanism.keys})
+        # Metadata excludes the structural keys (ID/SAMPLE_ID/ETYPE/ROLE); LoadMechanism columns
+        # are no longer in the dict at all post-rewire, so no extra exclusion needed.
         metadata = {k: v for k, v in dic.items() if k not in cls.keys}
         return cls(
             element_id=element_id,
@@ -117,11 +117,13 @@ class Element(Displayable):
     def from_pd_series(
         cls,
         element_series: pd.Series,
+        load_mechanism: LoadMechanism,
         display_engine: DisplayEngine | None = None,
         cache_mechanism: CacheMechanism | None = None,
     ):
         return cls.from_dict(
             {**element_series.to_dict()},
+            load_mechanism=load_mechanism,
             display_engine=display_engine,
             cache_mechanism=cache_mechanism,
         )

--- a/bridge/primitives/sample/sample.py
+++ b/bridge/primitives/sample/sample.py
@@ -12,6 +12,7 @@ from bridge.utils.helper import Displayable
 
 if TYPE_CHECKING:
     from bridge.display import DisplayEngine
+    from bridge.primitives.element.data.element_store import ElementStore
     from bridge.primitives.element.element_data_type import ELEMENT_DATA_TYPE
     from bridge.primitives.sample.transform.sample_transform import SampleTransform
 
@@ -95,6 +96,7 @@ class Sample(Displayable):
     def from_pd_dataframe(
         cls,
         elements_df: pd.DataFrame,
+        store: ElementStore,
         display_engine: DisplayEngine | None,
         cache_mechanisms: Dict[str, CacheMechanism | None],
     ):
@@ -110,10 +112,13 @@ class Sample(Displayable):
 
         elements = []
         for element_row in fast_to_dict_records(elements_df):
+            element_id = element_row[ELEMENT_COLS.ID]
             element_role = element_row.get(ELEMENT_COLS.ROLE, element_row[ELEMENT_COLS.ETYPE])
+            load_mechanism = store.get(element_id)
             elements.append(
                 Element.from_dict(
                     element_row,
+                    load_mechanism=load_mechanism,
                     display_engine=display_engine,
                     cache_mechanism=cache_mechanisms.get(element_role),
                 )

--- a/bridge/primitives/sample/transform/vision.py
+++ b/bridge/primitives/sample/transform/vision.py
@@ -179,8 +179,8 @@ class TorchvisionV2Transform(SampleTransform):
         else:
             raise NotImplementedError(f"Unsupported element type: {original_element.etype}")
 
-        provider = cache_mechanisms[original_element.etype].store(
-            original_element, transformed_data, as_encoding=new_encoding, should_update_elements=False
+        provider = cache_mechanisms[original_element.role].store(
+            original_element, transformed_data, as_encoding=new_encoding,
         )
 
         return Element(

--- a/bridge/primitives/sample/transform/vision.py
+++ b/bridge/primitives/sample/transform/vision.py
@@ -132,8 +132,13 @@ class TorchvisionV2Transform(SampleTransform):
         cache_mechanisms: Dict[str, CacheMechanism],
     ) -> Dict[str, List[Element]]:
         """Reconstruct elements dict with transformed data."""
-        # Start with a copy of all original elements to preserve untransformed ones
-        new_elements = copy.deepcopy(original_elements)
+        # Shallow-copy: preserve references to untransformed elements; deepcopy
+        # would recursively clone Element -> CacheMechanism -> ElementStore (a
+        # potentially huge per-lineage dict), which is both wasteful and wrong
+        # (the store is meant to be shared by reference). The transformed roles
+        # are replaced below with brand-new lists, so we never mutate any
+        # existing Element instance.
+        new_elements = {role: list(elems) for role, elems in original_elements.items()}
 
         # Update the image element with transformed data
         new_image_element = self._create_transformed_element(image_element, transformed_image, cache_mechanisms)

--- a/bridge/providers/vision.py
+++ b/bridge/providers/vision.py
@@ -40,7 +40,7 @@ class ImageFolder(DatasetProvider[SingularDataset, SingularSample]):
                     metadata={"filename": img_file.name},
                 )
                 class_element = Element(
-                    element_id=f"class_{i}",
+                    element_id=f"class_{sample_id}",
                     sample_id=sample_id,
                     etype="class_label",
                     load_mechanism=LoadMechanism(ClassLabel(i, class_dir.name), encoding="pickle"),

--- a/tests/core/test_aliasing_regression.py
+++ b/tests/core/test_aliasing_regression.py
@@ -1,0 +1,189 @@
+"""Regression test for the cache-aliasing bug.
+
+Today's behavior: when a Dataset is derived (via select/assign/sort/merge),
+all derived Datasets share the same CacheMechanism instance. The cache
+holds a reference to a DataFrame that gets reassigned at every Dataset
+construction (via _connect_caches → set_elements_df). After two
+derivations from the same parent, the cache only knows about the
+most-recently-constructed Dataset's DataFrame. Reads on any earlier
+Dataset write the URI bookkeeping into the wrong table.
+
+Expected behavior post-fix: all Datasets in a lineage share an
+ElementStore. Cache writes update the store; every Dataset sees the
+update via its derived `elements` property.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bridge.primitives.dataset import Dataset
+from bridge.primitives.element.data.cache_mechanism import CacheMechanism
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.data.uri_components import URIComponents
+from bridge.primitives.element.element import Element
+from bridge.utils.constants import ELEMENT_COLS
+from bridge.utils.data_objects import ClassLabel
+
+
+@pytest.fixture
+def tmp_cache_dir(tmp_path):
+    return tmp_path / "cache"
+
+
+@pytest.fixture
+def dataset_with_two_derivations(tmp_cache_dir):
+    """Build a Dataset of 4 in-memory image elements + a CacheMechanism
+    pointing at a temp dir, then derive two non-overlapping subsets.
+    """
+    elements = []
+    for i in range(4):
+        img = np.full((4, 4, 3), i, dtype=np.uint8)
+        elements.append(
+            Element(
+                element_id=f"img_{i}",
+                sample_id=i,
+                etype="image",
+                # encoding="pickle" rather than "jpeg" so the test runs in the
+                # core matrix (jpeg storage requires skimage from vision extras).
+                # The aliasing bug is encoding-agnostic; pickle exercises the same
+                # cache code path.
+                load_mechanism=LoadMechanism(img, encoding="pickle"),
+                metadata={"group": "a" if i < 2 else "b"},
+            )
+        )
+        elements.append(
+            Element(
+                element_id=f"label_{i}",
+                sample_id=i,
+                etype="class_label",
+                load_mechanism=LoadMechanism(ClassLabel(i), encoding="pickle"),
+            )
+        )
+    cache = CacheMechanism(URIComponents.from_str(str(tmp_cache_dir)))
+    ds = Dataset.from_elements(elements, cache_mechanisms={"image": cache})
+    ds_a = ds.select(lambda df: df["group"] == "a")
+    ds_b = ds.select(lambda df: df["group"] == "b")
+    return ds, ds_a, ds_b
+
+
+def test_aliasing_read_on_a_does_not_corrupt_b(dataset_with_two_derivations):
+    """Reading an element on ds_a must not change ds_b's view of any element.
+
+    Today, the cache mechanism's _elements pointer ends up at ds_b after
+    ds_b is constructed. A cache fire from ds_a writes the URI into
+    ds_b's DataFrame instead of ds_a's. This test catches that.
+    """
+    ds, ds_a, ds_b = dataset_with_two_derivations
+
+    # Snapshot ds_b's url_or_data column for image elements before reading anything
+    before_b = ds_b.elements.loc[
+        ds_b.elements[ELEMENT_COLS.ETYPE] == "image",
+        ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA,
+    ].tolist()
+
+    # Trigger a cache write on ds_a
+    sample = ds_a.iget(0)
+    _ = sample.one("image").data
+
+    # ds_b's image url_or_data must be exactly what it was before
+    after_b = ds_b.elements.loc[
+        ds_b.elements[ELEMENT_COLS.ETYPE] == "image",
+        ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA,
+    ].tolist()
+
+    assert len(before_b) == len(after_b), "row count changed"
+    for before_row, after_row in zip(before_b, after_b):
+        # An ndarray comparison via `==` returns an array; use np.array_equal
+        if isinstance(before_row, np.ndarray) and isinstance(after_row, np.ndarray):
+            assert np.array_equal(before_row, after_row), "ds_b's image data changed after read on ds_a"
+        else:
+            assert type(before_row) is type(after_row), (
+                f"ds_b's url_or_data type changed: {type(before_row)} -> {type(after_row)}"
+            )
+
+
+def test_aliasing_read_on_a_updates_a_view(dataset_with_two_derivations):
+    """After reading an element on ds_a (cache fires), ds_a's elements
+    should show the cached URI. This is the symmetric requirement: the
+    cache update must be visible on the Dataset that triggered it.
+    """
+    ds, ds_a, ds_b = dataset_with_two_derivations
+
+    sample = ds_a.iget(0)
+    _ = sample.one("image").data
+
+    # ds_a should now see a URIComponents (the cache location), not the
+    # original ndarray, in url_or_data for the image element it just read.
+    sample_id = sample.id
+    images = ds_a.elements.loc[
+        (ds_a.elements[ELEMENT_COLS.ETYPE] == "image"),
+    ]
+    matching = images.loc[
+        images.index.get_level_values(ELEMENT_COLS.SAMPLE_ID) == sample_id
+    ]
+    assert len(matching) == 1
+    new_value = matching[ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA].iloc[0]
+    assert isinstance(new_value, URIComponents), (
+        f"Expected URIComponents after cache fire, got {type(new_value).__name__}"
+    )
+
+
+def test_aliasing_read_on_a_propagates_to_b_when_element_id_present(dataset_with_two_derivations):
+    """If the element exists in both ds_a and ds_b (overlap case), a
+    cache fire on ds_a should be visible on ds_b. (In our fixture the
+    splits are disjoint so this doesn't apply to images, but we can test
+    via the parent ds, which contains all elements.)
+    """
+    ds, ds_a, ds_b = dataset_with_two_derivations
+
+    sample = ds_a.iget(0)
+    sample_id = sample.id
+    _ = sample.one("image").data
+
+    # The parent ds contains every element. The element we just cached
+    # should now show URIComponents in ds.elements too.
+    images = ds.elements.loc[
+        (ds.elements[ELEMENT_COLS.ETYPE] == "image"),
+    ]
+    matching = images.loc[
+        images.index.get_level_values(ELEMENT_COLS.SAMPLE_ID) == sample_id
+    ]
+    assert len(matching) == 1
+    new_value = matching[ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA].iloc[0]
+    assert isinstance(new_value, URIComponents), (
+        f"Expected URIComponents on parent ds after cache fire on derived ds_a, "
+        f"got {type(new_value).__name__}"
+    )
+
+
+def test_dataset_df_does_not_carry_location_columns(dataset_with_two_derivations):
+    """After ElementStore landed, Dataset._df should never carry url_or_data
+    or encoding columns — they live in the store. This invariant must
+    hold for derived Datasets too, not just freshly-constructed ones.
+    """
+    ds, ds_a, ds_b = dataset_with_two_derivations
+    url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
+    enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
+    for d in (ds, ds_a, ds_b):
+        assert url_col not in d._df.columns, f"_df has leaked {url_col} on {d!r}"
+        assert enc_col not in d._df.columns, f"_df has leaked {enc_col} on {d!r}"
+
+
+def test_cache_mechanism_rebind_to_different_store_raises(tmp_cache_dir):
+    """CacheMechanism is single-lineage. Rebinding to a different store is
+    a sign that the cache is being shared across independent Dataset
+    lineages, which would reintroduce the aliasing class of bug.
+    """
+    from bridge.primitives.element.data.element_store import ElementStore
+    cache = CacheMechanism(URIComponents.from_str(str(tmp_cache_dir)))
+    store_a = ElementStore()
+    store_b = ElementStore()
+    cache.bind_store(store_a)
+    # Rebinding to the same store is fine (idempotent for a lineage's
+    # multiple Datasets each calling bind_store).
+    cache.bind_store(store_a)
+    # Rebinding to a different store must raise.
+    with pytest.raises(ValueError, match="different ElementStore"):
+        cache.bind_store(store_b)

--- a/tests/core/test_cache_mechanism.py
+++ b/tests/core/test_cache_mechanism.py
@@ -4,8 +4,8 @@ import pandas as pd
 import pytest
 
 from bridge.primitives.element.data.cache_mechanism import CacheMechanism
+from bridge.primitives.element.data.element_store import ElementStore
 from bridge.primitives.element.data.uri_components import URIComponents
-from bridge.utils.constants import INDICES
 
 
 @pytest.fixture
@@ -55,16 +55,16 @@ def mock_data():
 def test_init(root_uri):
     cm = CacheMechanism(root_uri)
     assert cm._root_uri == root_uri
-    assert cm._elements is None
+    assert cm._store is None
 
 
-def test_set_elements_df(cache_mechanism):
-    df = pd.DataFrame({"id": [1, 2, 3]})
-    cache_mechanism.set_elements_df(df)
-    assert cache_mechanism._elements is df
+def test_bind_store(cache_mechanism):
+    store = ElementStore()
+    cache_mechanism.bind_store(store)
+    assert cache_mechanism._store is store
 
 
-def test_store(
+def test_store_without_bound_store(
     mock_is_registered,
     mock_store,
     mock_extension,
@@ -72,6 +72,7 @@ def test_store(
     mock_element,
     mock_data,
 ):
+    """When no store is bound, store() returns the new provider but doesn't update anything."""
     result = cache_mechanism.store(mock_element, mock_data)
 
     expected_uri = URIComponents(path="/root/path/test_id.ext")
@@ -79,7 +80,7 @@ def test_store(
     assert result == mock_store.return_value
 
 
-def test_store_update_elements(
+def test_store_updates_bound_store(
     mock_is_registered,
     mock_store,
     mock_extension,
@@ -87,29 +88,18 @@ def test_store_update_elements(
     mock_element,
     mock_data,
 ):
-    mock_store.return_value = Mock(to_dict=lambda: {"key1": "value1", "key2": "value2"})
-    mock_extension.return_value = ".ext"
+    """When a store is bound, store() also writes the new provider into it."""
+    new_provider = Mock(name="NewLoadMechanism")
+    mock_store.return_value = new_provider
 
-    elements_df = pd.DataFrame(
-        {
-            "sample_id": ["test_sample_id"],
-            "element_id": ["test_id"],
-            "key1": ["old1"],
-            "key2": ["old2"],
-        }
-    )
-    elements_df.set_index(INDICES, inplace=True)
-    cache_mechanism.set_elements_df(elements_df)
+    element_store = ElementStore()
+    # seed the store with an existing entry so update() has something to overwrite
+    element_store.update("test_id", Mock(name="OldLoadMechanism"))
+    cache_mechanism.bind_store(element_store)
 
-    cache_mechanism.store(mock_element, mock_data, should_update_elements=True)
+    cache_mechanism.store(mock_element, mock_data)
 
-    pd.testing.assert_frame_equal(
-        cache_mechanism._elements,
-        pd.DataFrame(
-            {"key1": ["value1"], "key2": ["value2"]},
-            index=pd.MultiIndex.from_tuples([("test_sample_id", "test_id")], names=INDICES),
-        ),
-    )
+    assert element_store.get("test_id") is new_provider
 
 
 def test_build_uri(mock_is_registered, mock_store, mock_extension, cache_mechanism, mock_element):

--- a/tests/core/test_dictable.py
+++ b/tests/core/test_dictable.py
@@ -62,13 +62,12 @@ def bad_load_mechanism_dict(request):
 
 
 @pytest.fixture
-def element_dict(load_mechanism_dict):
+def element_dict():
     return {
         ELEMENT_COLS.ID: "123",
         ELEMENT_COLS.ETYPE: "image",
         ELEMENT_COLS.ROLE: "image",
         ELEMENT_COLS.SAMPLE_ID: 0,
-        **load_mechanism_dict,
     }
 
 
@@ -82,9 +81,12 @@ def test_bad_load_mechanism_dict(bad_load_mechanism_dict):
         LoadMechanism.from_dict(bad_load_mechanism_dict)
 
 
-def test_element_from_dict(mocker, element_dict):
+def test_element_from_dict(mocker, element_dict, load_mechanism_dict):
     de_mock = mocker.Mock(spec=DisplayEngine)
     cm_mock = mocker.Mock(spec=CacheMechanism)
-    element = Element.from_dict(element_dict, display_engine=de_mock, cache_mechanism=cm_mock)
+    load_mechanism = LoadMechanism.from_dict(load_mechanism_dict)
+    element = Element.from_dict(
+        element_dict, load_mechanism=load_mechanism, display_engine=de_mock, cache_mechanism=cm_mock
+    )
     dic = element.to_dict()
     assert dic == element_dict

--- a/tests/core/test_element.py
+++ b/tests/core/test_element.py
@@ -74,7 +74,7 @@ def test_validate_metadata(load_mechanism_mock, display_engine_mock, cache_mecha
             load_mechanism=load_mechanism_mock,
             display_engine=display_engine_mock,
             cache_mechanism=cache_mechanism_mock,
-            metadata={"source": "lol", "data": "dsadsa"},
+            metadata={"source": "lol", "element_id": "dsadsa"},
         )
 
 

--- a/tests/core/test_element_store.py
+++ b/tests/core/test_element_store.py
@@ -1,0 +1,85 @@
+"""Tests for the ElementStore — the shared per-lineage location store."""
+
+from __future__ import annotations
+
+import pytest
+
+from bridge.primitives.element.data.element_store import ElementStore
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+
+
+def _lm(value="x", encoding="pickle") -> LoadMechanism:
+    return LoadMechanism(value, encoding=encoding)
+
+
+def test_empty_store_has_zero_length():
+    store = ElementStore()
+    assert len(store) == 0
+
+
+def test_set_and_get():
+    store = ElementStore()
+    lm = _lm("hello")
+    store.set("e0", lm)
+    assert store.get("e0") is lm
+
+
+def test_contains():
+    store = ElementStore()
+    store.set("e0", _lm())
+    assert "e0" in store
+    assert "missing" not in store
+
+
+def test_get_missing_raises_keyerror():
+    store = ElementStore()
+    with pytest.raises(KeyError):
+        store.get("missing")
+
+
+def test_set_existing_key_raises():
+    store = ElementStore()
+    store.set("e0", _lm("v1"))
+    with pytest.raises(ValueError, match="already has"):
+        store.set("e0", _lm("v2"))
+
+
+def test_update_overwrites():
+    store = ElementStore()
+    store.set("e0", _lm("v1"))
+    store.update("e0", _lm("v2"))
+    assert store.get("e0").url_or_data == "v2"
+
+
+def test_update_creates_if_absent():
+    """update() is set-or-overwrite; no error for a missing key."""
+    store = ElementStore()
+    store.update("e0", _lm("v"))
+    assert store.get("e0").url_or_data == "v"
+
+
+def test_extend_merges_two_disjoint_stores():
+    a = ElementStore()
+    a.set("e0", _lm("a"))
+    b = ElementStore()
+    b.set("e1", _lm("b"))
+    a.extend(b)
+    assert len(a) == 2
+    assert a.get("e0").url_or_data == "a"
+    assert a.get("e1").url_or_data == "b"
+
+
+def test_extend_overlap_raises():
+    a = ElementStore()
+    a.set("e0", _lm("a"))
+    b = ElementStore()
+    b.set("e0", _lm("b"))
+    with pytest.raises(ValueError, match="overlap"):
+        a.extend(b)
+
+
+def test_iteration_returns_element_ids():
+    store = ElementStore()
+    store.set("e0", _lm())
+    store.set("e1", _lm())
+    assert set(store) == {"e0", "e1"}

--- a/tests/core/test_element_store.py
+++ b/tests/core/test_element_store.py
@@ -33,7 +33,7 @@ def test_contains():
 
 def test_get_missing_raises_keyerror():
     store = ElementStore()
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="element_id="):
         store.get("missing")
 
 

--- a/tests/core/test_role.py
+++ b/tests/core/test_role.py
@@ -61,7 +61,7 @@ def test_role_appears_in_to_dict():
 def test_to_dict_round_trip_preserves_role():
     elem = _make_element(etype="image", role="target")
     d = elem.to_dict()
-    rebuilt = Element.from_dict(d)
+    rebuilt = Element.from_dict(d, load_mechanism=elem._load_mechanism)
     assert rebuilt.role == "target"
     assert rebuilt.etype == "image"
 
@@ -71,7 +71,7 @@ def test_from_dict_tolerates_missing_role_key():
     elem = _make_element(etype="text")
     d = elem.to_dict()
     d.pop(ELEMENT_COLS.ROLE)  # simulate old data
-    rebuilt = Element.from_dict(d)
+    rebuilt = Element.from_dict(d, load_mechanism=elem._load_mechanism)
     assert rebuilt.role == "text"  # falls back to etype
     assert rebuilt.etype == "text"
 


### PR DESCRIPTION
## Summary

Third sub-branch of the v0.2 multi-role rewrite. **Fixes the cache aliasing bug** flagged in the original architecture review.

### The bug

`CacheMechanism` mutates `self._elements` (a DataFrame reference) that gets reassigned at every Dataset construction via `_connect_caches → set_elements_df`. After `ds_a = ds.select(...)` and `ds_b = ds.select(...)`, the cache only knows about the most-recently-constructed Dataset's DataFrame. Reads on `ds_a` write into `ds_b`'s table — silent corruption that the test suite never exercised.

### The fix

- New `ElementStore` (Dict[element_id, LoadMechanism]) — shared by reference across Datasets in a lineage. Reference is never reassigned; only contents mutate.
- `Dataset._df` stops carrying `url_or_data` / `encoding` columns; they live in the shared store.
- `Dataset.elements` is now a derived view that joins `_df` with current store contents on access. **User-visible behavior is unchanged.**
- `CacheMechanism.store(...)` writes bytes to disk and `store.update(element_id, new_lm)`. No more DataFrame mutation.
- `CacheMechanism.bind_store(store)` raises if rebound to a different store, preventing the same aliasing class one level up.

### Cleanups that fall out

- `_connect_caches` removed (replaced by `bind_store` on CacheMechanism, called once per Dataset construction).
- `set_elements_df` and `_update_samples_with_new_provider` removed.
- `should_update_elements` flag on `CacheMechanism.store` removed.
- `URIComponents.__next__` hack removed (URIs no longer in pandas columns).
- `Element.to_dict` drops url_or_data/encoding columns; `from_dict` accepts a `load_mechanism` arg.

### Latent bug discovered and fixed

`ImageFolder` provider had `element_id="class_{i}"` (where `i` was a class index). With multiple samples per class, this collided across samples — silently overwriting in the old cache_mechanisms dict, but caught by `ElementStore.set` raising on duplicate ids. Fixed to `class_{sample_id}`.

### Regression tests

`tests/core/test_aliasing_regression.py` — 5 TDD-style tests:

1. `test_aliasing_read_on_a_does_not_corrupt_b` — derives two non-overlapping subsets, reads from one, verifies the other's view is untouched.
2. `test_aliasing_read_on_a_updates_a_view` — verifies the cache update is visible on the Dataset that triggered it.
3. `test_aliasing_read_on_a_propagates_to_b_when_element_id_present` — verifies the parent (which contains every element) sees the update too.
4. `test_dataset_df_does_not_carry_location_columns` — invariant that `_df` never has location columns, including across derivations.
5. `test_cache_mechanism_rebind_to_different_store_raises` — guard against the aliasing class one level up.

These would fail on `feature/v0.2`'s tip (in the bug-reproducing way); they pass after this change.

## Commits

```
d8fdc10 refactor: introduce ElementStore as canonical location store
8b62399 feat(element): add ElementStore class for shared location state
```

## Test plan

- [x] 10 ElementStore unit tests (`tests/core/test_element_store.py`)
- [x] 5 aliasing regression tests (`tests/core/test_aliasing_regression.py`)
- [x] All 103 baseline tests still pass (after small fixture / signature adjustments)
- [x] 9 notebook integration tests pass (~13 min wall time — see Risks)

## Risks

- Notebook suite ran ~13 min on this branch (vs ~4-5 min on `feature/v0.2`'s tip). Most likely culprit: the back-compat `Dataset._extract_store_from_df` uses `df.iterrows()` which is slow for large DataFrames; some notebooks build Datasets from DataFrames containing 5K+ rows. Could vectorize as a follow-up.
- `Dataset.elements` is O(n) per access (synthesizes location columns from store on every call). `SingularDataset.samples` and `annotations` go through `self.elements` and are themselves called multiple times per derivation. Possible optimization: filter on `self._df` first, then join location for the smaller subset. Deferred.
- ~118 LoC of changes to test files for the new APIs. Not "surprise breakage" — intentional adaptations.

## Next sub-branch

`feature/providers-v2` — restructure providers into vision/text/multimodal subpackages. Will use multi-role + ElementStore properly.