### PR TITLE
Display shape split: per-shape engines (v0.2 #5)

### DIFF
--- a/bridge/display/multimodal/__init__.py
+++ b/bridge/display/multimodal/__init__.py
@@ -1,0 +1,3 @@
+from bridge.display.multimodal.captioned_images import CaptionedImagesPanelEngine
+
+__all__ = ["CaptionedImagesPanelEngine"]

--- a/bridge/display/multimodal/captioned_images.py
+++ b/bridge/display/multimodal/captioned_images.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+import numpy as np
+
+from bridge.display.display_engine import DisplayEngine
+from bridge.utils import optional_dependencies
+
+if TYPE_CHECKING:
+    from bridge.primitives.dataset import Dataset
+    from bridge.primitives.element.element import Element
+    from bridge.primitives.sample import Sample
+
+
+class CaptionedImagesPanelEngine(DisplayEngine):
+    """Renders image + caption text samples.
+
+    Expected sample shape:
+      - role ``image`` (etype ``image``) — required
+      - role ``caption`` (etype ``text``) — required, displayed as Markdown alongside the image
+    """
+
+    IMAGE_ROLE = "image"
+    CAPTION_ROLE = "caption"
+
+    def show_element(self, element: Element, element_plot_kwargs: Dict[str, Any] | None = None):
+        self._validate_dependencies()
+        if element.etype == "image":
+            return self._plot_single_image(element)
+        if element.etype == "text":
+            import panel as pn
+
+            return pn.pane.Markdown(element.data)
+        raise NotImplementedError(f"CaptionedImagesPanelEngine cannot render etype={element.etype}")
+
+    def show_sample(
+        self,
+        sample: Sample,
+        element_plot_kwargs: Dict[str, Any] | None = None,
+        sample_plot_kwargs: Dict[str, Any] | None = None,
+    ):
+        self._validate_dependencies()
+        import panel as pn
+
+        for role in (self.IMAGE_ROLE, self.CAPTION_ROLE):
+            if role not in sample.elements:
+                raise ValueError(
+                    f"CaptionedImagesPanelEngine requires '{self.IMAGE_ROLE}' and "
+                    f"'{self.CAPTION_ROLE}' roles; missing '{role}'"
+                )
+
+        img_pane = pn.pane.HoloViews(self._plot_single_image(sample.elements[self.IMAGE_ROLE][0]))
+        caption_pane = pn.pane.Markdown(f"**Caption:** {sample.elements[self.CAPTION_ROLE][0].data}")
+        return pn.Row(img_pane, caption_pane)
+
+    def show_dataset(
+        self,
+        dataset: Dataset,
+        element_plot_kwargs: Dict[str, Any] | None = None,
+        sample_plot_kwargs: Dict[str, Any] | None = None,
+        dataset_plot_kwargs: Dict[str, Any] | None = None,
+    ):
+        self._validate_dependencies()
+        import panel as pn
+
+        sample_ids = dataset.sample_ids
+        sample_ids_wig = pn.widgets.DiscreteSlider(name="Sample ID", options=sample_ids, value=sample_ids[0])
+
+        @pn.depends(sample_ids_wig.param.value)
+        def plot_sample_by_widget(sample_id):
+            return self.show_sample(
+                dataset.get(sample_id),
+                element_plot_kwargs=element_plot_kwargs,
+                sample_plot_kwargs=sample_plot_kwargs,
+            )
+
+        return pn.Column(sample_ids_wig, plot_sample_by_widget)
+
+    def _plot_single_image(self, element: Element):
+        import holoviews as hv
+
+        if element.encoding == "jpeg":
+            data: np.ndarray = element.data
+        elif element.encoding == "pt":
+            data: np.ndarray = element.data.permute(1, 2, 0).numpy()
+        else:
+            raise NotImplementedError(f"Unsupported encoding for image: {element.encoding}")
+
+        h, w = data.shape[0], data.shape[1]
+        if len(data.shape) == 2:
+            data = data[:, :, np.newaxis].repeat(3, axis=-1)
+        return hv.RGB(data[::-1, :, :], bounds=(0, 0, w, h)).opts(
+            aspect="equal", invert_yaxis=True, xaxis=None, yaxis=None
+        )
+
+    @staticmethod
+    def _validate_dependencies():
+        with optional_dependencies("raise"):
+            import holoviews  # noqa
+            import panel  # noqa
+
+        assert (
+            holoviews.Store.current_backend == "bokeh"
+        ), f"Holoviews backend: {holoviews.Store.current_backend} is not supported."

--- a/bridge/display/multimodal/captioned_images.py
+++ b/bridge/display/multimodal/captioned_images.py
@@ -50,8 +50,8 @@ class CaptionedImagesPanelEngine(DisplayEngine):
                     f"'{self.CAPTION_ROLE}' roles; missing '{role}'"
                 )
 
-        img_pane = pn.pane.HoloViews(self._plot_single_image(sample.elements[self.IMAGE_ROLE][0]))
-        caption_pane = pn.pane.Markdown(f"**Caption:** {sample.elements[self.CAPTION_ROLE][0].data}")
+        img_pane = pn.pane.HoloViews(self._plot_single_image(sample.one(self.IMAGE_ROLE)))
+        caption_pane = pn.pane.Markdown(f"**Caption:** {sample.one(self.CAPTION_ROLE).data}")
         return pn.Row(img_pane, caption_pane)
 
     def show_dataset(

--- a/bridge/display/text/__init__.py
+++ b/bridge/display/text/__init__.py
@@ -1,0 +1,8 @@
+from bridge.display.text.classification import TextClassificationPanelEngine
+
+# Back-compat alias. The old generic name is preserved so existing notebooks,
+# tests, and provider defaults keep working until feature/notebooks-rewrite
+# updates everything to the new names.
+Panel = TextClassificationPanelEngine
+
+__all__ = ["TextClassificationPanelEngine", "Panel"]

--- a/bridge/display/text/classification.py
+++ b/bridge/display/text/classification.py
@@ -13,7 +13,14 @@ if TYPE_CHECKING:
     from bridge.primitives.element.element import Element
 
 
-class Panel(DisplayEngine[SingularDataset, SingularSample]):
+class TextClassificationPanelEngine(DisplayEngine[SingularDataset, SingularSample]):
+    """Renders text + class_label samples.
+
+    Expected sample shape:
+      - role ``text`` (etype ``text``) — required, displayed as Markdown
+      - role ``class_label`` (etype ``class_label``) — optional, rendered as a Markdown table
+    """
+
     def show_element(self, element: Element, element_plot_kwargs: Dict[str, Any] | None = None):
         if element.etype == "class_label":
             return pn.pane.Markdown(element.to_pd_series().to_frame().T.to_markdown())

--- a/bridge/display/vision/__init__.py
+++ b/bridge/display/vision/__init__.py
@@ -1,0 +1,8 @@
+from bridge.display.vision.detection import DetectionPanelEngine
+
+# Back-compat alias. The old generic name is preserved so existing notebooks,
+# tests, and provider defaults keep working until feature/notebooks-rewrite
+# updates everything to the new names.
+Panel = DetectionPanelEngine
+
+__all__ = ["DetectionPanelEngine", "Panel"]

--- a/bridge/display/vision/__init__.py
+++ b/bridge/display/vision/__init__.py
@@ -1,8 +1,9 @@
 from bridge.display.vision.detection import DetectionPanelEngine
+from bridge.display.vision.image_pairs import ImagePairsPanelEngine
 
 # Back-compat alias. The old generic name is preserved so existing notebooks,
 # tests, and provider defaults keep working until feature/notebooks-rewrite
 # updates everything to the new names.
 Panel = DetectionPanelEngine
 
-__all__ = ["DetectionPanelEngine", "Panel"]
+__all__ = ["DetectionPanelEngine", "ImagePairsPanelEngine", "Panel"]

--- a/bridge/display/vision/detection.py
+++ b/bridge/display/vision/detection.py
@@ -15,7 +15,15 @@ if TYPE_CHECKING:
     from bridge.utils.data_objects import BoundingBox
 
 
-class Panel(DisplayEngine):
+class DetectionPanelEngine(DisplayEngine):
+    """Renders image + bbox (+ optional class_label) samples.
+
+    Expected sample shape:
+      - role ``image`` (etype ``image``) — required
+      - role ``bbox`` (etype ``bbox``) — optional, overlaid on the image
+      - role ``class_label`` (etype ``class_label``) — optional, rendered alongside bboxes
+    """
+
     def __init__(self, bbox_format: str = "xyxy") -> None:
         assert bbox_format in ["xyxy", "xywh", "cxcywh"]
         self._bbox_format = bbox_format

--- a/bridge/display/vision/image_pairs.py
+++ b/bridge/display/vision/image_pairs.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+import numpy as np
+
+from bridge.display.display_engine import DisplayEngine
+from bridge.utils import optional_dependencies
+
+if TYPE_CHECKING:
+    from bridge.primitives.dataset import Dataset
+    from bridge.primitives.element.element import Element
+    from bridge.primitives.sample import Sample
+
+
+class ImagePairsPanelEngine(DisplayEngine):
+    """Renders source/target image-pair samples side-by-side.
+
+    Expected sample shape:
+      - role ``source`` (etype ``image``) — required
+      - role ``target`` (etype ``image``) — required
+    """
+
+    SOURCE_ROLE = "source"
+    TARGET_ROLE = "target"
+
+    def show_element(self, element: Element, element_plot_kwargs: Dict[str, Any] | None = None):
+        self._validate_dependencies()
+        if element.etype != "image":
+            raise NotImplementedError(
+                f"ImagePairsPanelEngine only renders image elements, got etype={element.etype}"
+            )
+        plot = self._plot_single_image(element)
+        if element_plot_kwargs:
+            plot = plot.opts(**element_plot_kwargs)
+        return plot
+
+    def show_sample(
+        self,
+        sample: Sample,
+        element_plot_kwargs: Dict[str, Any] | None = None,
+        sample_plot_kwargs: Dict[str, Any] | None = None,
+    ):
+        self._validate_dependencies()
+        import holoviews as hv
+
+        for role in (self.SOURCE_ROLE, self.TARGET_ROLE):
+            if role not in sample.elements:
+                raise ValueError(
+                    f"ImagePairsPanelEngine requires both '{self.SOURCE_ROLE}' and "
+                    f"'{self.TARGET_ROLE}' roles; missing '{role}'"
+                )
+
+        source_plot = self._plot_single_image(sample.elements[self.SOURCE_ROLE][0]).opts(title="source")
+        target_plot = self._plot_single_image(sample.elements[self.TARGET_ROLE][0]).opts(title="target")
+        return hv.Layout([source_plot, target_plot]).cols(2)
+
+    def show_dataset(
+        self,
+        dataset: Dataset,
+        element_plot_kwargs: Dict[str, Any] | None = None,
+        sample_plot_kwargs: Dict[str, Any] | None = None,
+        dataset_plot_kwargs: Dict[str, Any] | None = None,
+    ):
+        self._validate_dependencies()
+        import panel as pn
+
+        sample_ids = dataset.sample_ids
+        sample_ids_wig = pn.widgets.DiscreteSlider(name="Sample ID", options=sample_ids, value=sample_ids[0])
+
+        @pn.depends(sample_ids_wig.param.value)
+        def plot_sample_by_widget(sample_id):
+            return self.show_sample(
+                dataset.get(sample_id),
+                element_plot_kwargs=element_plot_kwargs,
+                sample_plot_kwargs=sample_plot_kwargs,
+            )
+
+        return pn.Column(sample_ids_wig, plot_sample_by_widget)
+
+    def _plot_single_image(self, element: Element):
+        import holoviews as hv
+
+        if element.encoding == "jpeg":
+            data: np.ndarray = element.data
+        elif element.encoding == "pt":
+            data: np.ndarray = element.data.permute(1, 2, 0).numpy()
+        else:
+            raise NotImplementedError(f"Unsupported encoding for image: {element.encoding}")
+
+        h, w = data.shape[0], data.shape[1]
+        if len(data.shape) == 2:
+            data = data[:, :, np.newaxis].repeat(3, axis=-1)
+        return hv.RGB(data[::-1, :, :], bounds=(0, 0, w, h)).opts(
+            aspect="equal", invert_yaxis=True, xaxis=None, yaxis=None
+        )
+
+    @staticmethod
+    def _validate_dependencies():
+        with optional_dependencies("raise"):
+            import holoviews  # noqa
+            import panel  # noqa
+
+        assert (
+            holoviews.Store.current_backend == "bokeh"
+        ), f"Holoviews backend: {holoviews.Store.current_backend} is not supported."

--- a/bridge/display/vision/image_pairs.py
+++ b/bridge/display/vision/image_pairs.py
@@ -51,8 +51,8 @@ class ImagePairsPanelEngine(DisplayEngine):
                     f"'{self.TARGET_ROLE}' roles; missing '{role}'"
                 )
 
-        source_plot = self._plot_single_image(sample.elements[self.SOURCE_ROLE][0]).opts(title="source")
-        target_plot = self._plot_single_image(sample.elements[self.TARGET_ROLE][0]).opts(title="target")
+        source_plot = self._plot_single_image(sample.one(self.SOURCE_ROLE)).opts(title="source")
+        target_plot = self._plot_single_image(sample.one(self.TARGET_ROLE)).opts(title="target")
         return hv.Layout([source_plot, target_plot]).cols(2)
 
     def show_dataset(

--- a/bridge/primitives/dataset/dataset.py
+++ b/bridge/primitives/dataset/dataset.py
@@ -92,6 +92,10 @@ class Dataset(TableAPI, SampleAPI, Displayable):
     def sample_ids(self) -> List[Hashable]:
         return self._df.index.get_level_values(ELEMENT_COLS.SAMPLE_ID).drop_duplicates().to_list()
 
+    @property
+    def display_engine(self) -> DisplayEngine | None:
+        return self._display_engine
+
     def select(self, selector: Callable):
         # selector receives the user-facing elements (with location columns) for filtering
         selected = selector(self.elements)

--- a/bridge/providers/multimodal/captioned_images.py
+++ b/bridge/providers/multimodal/captioned_images.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
+from bridge.display.multimodal import CaptionedImagesPanelEngine
 from bridge.primitives.dataset import Dataset
 from bridge.primitives.element.data.load_mechanism import LoadMechanism
 from bridge.primitives.element.element import Element
@@ -57,7 +58,7 @@ class CaptionedImages(DatasetProvider[Dataset, Sample]):
 
     def build_dataset(
         self,
-        display_engine: DisplayEngine | None = None,
+        display_engine: DisplayEngine | None = CaptionedImagesPanelEngine(),
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> Dataset:
         with self._captions_path.open() as f:

--- a/bridge/providers/vision/image_pairs.py
+++ b/bridge/providers/vision/image_pairs.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
-from bridge.display.vision import Panel
+from bridge.display.vision import ImagePairsPanelEngine
 from bridge.primitives.dataset import Dataset
 from bridge.primitives.element.data.load_mechanism import LoadMechanism
 from bridge.primitives.element.element import Element
@@ -51,7 +51,7 @@ class ImagePairs(DatasetProvider[Dataset, Sample]):
 
     def build_dataset(
         self,
-        display_engine: DisplayEngine | None = Panel(),
+        display_engine: DisplayEngine | None = ImagePairsPanelEngine(),
         cache_mechanisms: Dict[str, CacheMechanism | None] | None = None,
     ) -> Dataset:
         source_files = _collect_files_by_stem(self._source_dir)

--- a/tests/multimodal/conftest.py
+++ b/tests/multimodal/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for multimodal tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _holoviews_bokeh_backend():
+    """Panel display engines assert the holoviews backend is bokeh; notebooks
+    set this via hv.extension('bokeh'). Match that here so tests don't need
+    to repeat the dance."""
+    import holoviews as hv
+
+    hv.extension("bokeh")

--- a/tests/multimodal/test_captioned_images_engine.py
+++ b/tests/multimodal/test_captioned_images_engine.py
@@ -1,0 +1,60 @@
+"""Smoke tests for CaptionedImagesPanelEngine."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from bridge.display.multimodal import CaptionedImagesPanelEngine
+from bridge.providers.multimodal import CaptionedImages
+
+
+def _write_jpeg(path: Path, h: int = 16, w: int = 16) -> None:
+    arr = np.random.randint(0, 255, size=(h, w, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(path, format="JPEG")
+
+
+@pytest.fixture
+def captioned_dataset(tmp_path):
+    img_dir = tmp_path / "images"
+    img_dir.mkdir()
+    captions = {}
+    for name in ("a", "b"):
+        _write_jpeg(img_dir / f"{name}.jpg")
+        captions[name] = f"Caption for {name}"
+    (tmp_path / "captions.json").write_text(json.dumps(captions))
+    return CaptionedImages(tmp_path).build_dataset()
+
+
+def test_captioned_engine_show_sample(captioned_dataset):
+    engine = CaptionedImagesPanelEngine()
+    out = engine.show_sample(captioned_dataset.iget(0))
+    assert out is not None
+
+
+def test_captioned_engine_show_element_image(captioned_dataset):
+    engine = CaptionedImagesPanelEngine()
+    sample = captioned_dataset.iget(0)
+    out = engine.show_element(sample.one("image"))
+    assert out is not None
+
+
+def test_captioned_engine_show_element_caption(captioned_dataset):
+    engine = CaptionedImagesPanelEngine()
+    sample = captioned_dataset.iget(0)
+    out = engine.show_element(sample.one("caption"))
+    assert out is not None
+
+
+def test_captioned_engine_show_dataset(captioned_dataset):
+    engine = CaptionedImagesPanelEngine()
+    out = engine.show_dataset(captioned_dataset)
+    assert out is not None
+
+
+def test_captioned_provider_default_engine_is_captioned(captioned_dataset):
+    """Provider should default to the matching shape engine."""
+    assert isinstance(captioned_dataset._display_engine, CaptionedImagesPanelEngine)

--- a/tests/multimodal/test_captioned_images_engine.py
+++ b/tests/multimodal/test_captioned_images_engine.py
@@ -57,4 +57,15 @@ def test_captioned_engine_show_dataset(captioned_dataset):
 
 def test_captioned_provider_default_engine_is_captioned(captioned_dataset):
     """Provider should default to the matching shape engine."""
-    assert isinstance(captioned_dataset._display_engine, CaptionedImagesPanelEngine)
+    assert isinstance(captioned_dataset.display_engine, CaptionedImagesPanelEngine)
+
+
+def test_captioned_engine_missing_role_raises(captioned_dataset):
+    """show_sample must raise ValueError naming the missing role."""
+    from bridge.primitives.sample import Sample
+
+    engine = CaptionedImagesPanelEngine()
+    sample = captioned_dataset.iget(0)
+    stripped = Sample(elements={"image": sample.elements["image"]})
+    with pytest.raises(ValueError, match="caption"):
+        engine.show_sample(stripped)

--- a/tests/vision/test_image_pairs_engine.py
+++ b/tests/vision/test_image_pairs_engine.py
@@ -1,0 +1,50 @@
+"""Smoke tests for ImagePairsPanelEngine on synthetic pair data."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from bridge.display.vision import ImagePairsPanelEngine
+from bridge.providers.vision import ImagePairs
+
+
+def _write_jpeg(path: Path, h: int = 16, w: int = 16) -> None:
+    arr = np.random.randint(0, 255, size=(h, w, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(path, format="JPEG")
+
+
+@pytest.fixture
+def pair_dataset(tmp_path):
+    for sub in ("source", "target"):
+        d = tmp_path / sub
+        d.mkdir()
+        for name in ("a", "b"):
+            _write_jpeg(d / f"{name}.jpg")
+    return ImagePairs(tmp_path).build_dataset()
+
+
+def test_image_pairs_engine_show_sample(pair_dataset):
+    engine = ImagePairsPanelEngine()
+    out = engine.show_sample(pair_dataset.iget(0))
+    assert out is not None
+
+
+def test_image_pairs_engine_show_element_image(pair_dataset):
+    engine = ImagePairsPanelEngine()
+    sample = pair_dataset.iget(0)
+    out = engine.show_element(sample.one("source"))
+    assert out is not None
+
+
+def test_image_pairs_engine_show_dataset(pair_dataset):
+    engine = ImagePairsPanelEngine()
+    out = engine.show_dataset(pair_dataset)
+    assert out is not None
+
+
+def test_image_pairs_provider_default_engine_is_image_pairs(pair_dataset):
+    """The provider should default to the matching shape engine."""
+    assert isinstance(pair_dataset._display_engine, ImagePairsPanelEngine)

--- a/tests/vision/test_image_pairs_engine.py
+++ b/tests/vision/test_image_pairs_engine.py
@@ -47,4 +47,16 @@ def test_image_pairs_engine_show_dataset(pair_dataset):
 
 def test_image_pairs_provider_default_engine_is_image_pairs(pair_dataset):
     """The provider should default to the matching shape engine."""
-    assert isinstance(pair_dataset._display_engine, ImagePairsPanelEngine)
+    assert isinstance(pair_dataset.display_engine, ImagePairsPanelEngine)
+
+
+def test_image_pairs_engine_missing_role_raises(pair_dataset):
+    """show_sample must raise ValueError naming the missing role."""
+    from bridge.primitives.sample import Sample
+
+    engine = ImagePairsPanelEngine()
+    sample = pair_dataset.iget(0)
+    # Build a degenerate sample with only the source role
+    stripped = Sample(elements={"source": sample.elements["source"]})
+    with pytest.raises(ValueError, match="target"):
+        engine.show_sample(stripped)


### PR DESCRIPTION
## Summary
- Restructure `bridge/display/` into `vision/`, `text/`, `multimodal/` subpackages — same layout as `bridge/providers/` after #24.
- Rename `vision.Panel` → `DetectionPanelEngine` and `text.Panel` → `TextClassificationPanelEngine` to make sample-shape contracts explicit. `Panel` kept as an alias in both subpackages, so notebooks/tests/provider defaults that import `Panel` keep working — those will be cleaned up in `feature/notebooks-rewrite`.
- Add `ImagePairsPanelEngine` (vision, side-by-side source/target) and `CaptionedImagesPanelEngine` (multimodal, image + caption text) for the multi-role example providers introduced in #24.
- Wire each new engine as the default in its provider; add a public `Dataset.display_engine` property to test wiring without reaching into private state.

## Test plan
- [x] Existing `tests/vision/test_display.py` (10 tests) and `test_providers.py` (7 tests) pass via the back-compat `Panel` alias
- [x] New smoke tests for `ImagePairsPanelEngine` (5 tests) and `CaptionedImagesPanelEngine` (6 tests) — show_element / show_sample / show_dataset on synthetic data, plus negative-path tests asserting `ValueError` names the missing role
- [x] Full unit suite: 139 passed