### PR TITLE
Test hardening (v0.2 #7)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for your interest in `bridge-ds`! This document captures the
+conventions we ask contributors to follow.
+
+## Test conventions
+
+The test suite is split by extras matrix:
+
+- `tests/core/` runs against the **base install** (no optional extras).
+- `tests/vision/` and `tests/multimodal/` may rely on the `vision` extra.
+
+Tests under `tests/core/` must run in a no-extras (Python-only) venv. They
+must not exercise encodings that lazy-import optional deps:
+
+- **Allowed encodings**: `pickle`, `utf8`, `npy`
+- **Forbidden encodings**: `jpeg`, `pt`, anything else that requires the
+  `vision` extra (or any other optional dependency)
+
+Local dev typically runs `uv sync --extra vision`, so a `tests/core/` test
+that accidentally exercises a vision-extra import will pass locally but
+fail on CI's core matrix. To catch this before pushing, run the
+no-extras safety hook:
+
+```bash
+bash scripts/check_core_no_extras.sh
+```
+
+The script creates a throwaway venv with only the base project
+dependencies + pytest, then runs `pytest tests/core` against it. Run it
+before pushing a PR that touches `bridge/` or `tests/core/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pandas>=2.0",
     "numpy>=1.24",
     "tqdm>=4.60",
+    "typing_extensions>=4.0",
 ]
 [project.optional-dependencies]
 vision = [

--- a/scripts/check_core_no_extras.sh
+++ b/scripts/check_core_no_extras.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run tests/core in a fresh no-extras venv to catch cross-matrix issues.
+#
+# Local dev is typically `uv sync --extra vision`, so a tests/core test that
+# accidentally exercises a vision-extra import will pass locally but fail on
+# CI's core matrix. This script creates a throwaway venv that installs only
+# the project's [project] dependencies plus pytest (no `vision` or other
+# extra) and runs `pytest tests/core` against it.
+#
+# Usage: bash scripts/check_core_no_extras.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_VENV="$(mktemp -d)"
+trap 'rm -rf "$TMP_VENV"' EXIT
+
+uv venv "$TMP_VENV"
+# Install the project (no extras) into the throwaway venv.
+VIRTUAL_ENV="$TMP_VENV" uv pip install --quiet -e "$REPO_ROOT"
+# Install just the test runner; do NOT pull in the dev group (which would
+# bring torch/torchvision and is unnecessary for tests/core).
+VIRTUAL_ENV="$TMP_VENV" uv pip install --quiet pytest pytest-mock
+
+cd "$REPO_ROOT"
+"$TMP_VENV/bin/pytest" tests/core -q "$@"

--- a/tests/core/test_dataset_assign.py
+++ b/tests/core/test_dataset_assign.py
@@ -1,0 +1,72 @@
+"""Pin Dataset.assign(data=...) no-propagate behavior — discovered during notebook migration.
+
+The notebook migration revealed that `Dataset.assign(data=...)` writes a
+column to `_df`, but that column is overridden every time `ds.elements`
+is accessed (because `_join_locations` synthesizes `data` and `encoding`
+from the store). This is the deliberate post-v0.2 design — the load
+mechanism layer is the source of truth — but it's surprising for callers
+who'd expect `assign` to behave like `pandas.DataFrame.assign`.
+
+Pin the current behavior so future API changes are forced to be
+intentional. If a future PR changes `assign` semantics, these tests will
+turn red and the change will be reviewed.
+"""
+from __future__ import annotations
+
+from bridge.primitives.dataset import Dataset
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.element import Element
+from bridge.utils.constants import ELEMENT_COLS
+
+
+def _trivial_pickle_dataset(n: int = 3) -> Dataset:
+    elems = [
+        Element(
+            element_id=f"e_{i}",
+            sample_id=i,
+            etype="t",
+            load_mechanism=LoadMechanism(f"data-{i}", encoding="pickle"),
+        )
+        for i in range(n)
+    ]
+    return Dataset.from_role_dict({"t": elems})
+
+
+def test_assign_metadata_persists_through_elements_view():
+    """Sanity check: arbitrary metadata columns set via `assign` survive
+    the elements view. (If this test fails, the elements view is doing
+    something weirder than just synthesizing the load-mechanism columns.)
+    """
+    ds = _trivial_pickle_dataset(3)
+    ds_with_meta = ds.assign(custom=lambda df: ["a", "b", "c"])
+    assert "custom" in ds_with_meta.elements.columns
+    assert list(ds_with_meta.elements["custom"]) == ["a", "b", "c"]
+
+
+def test_assign_to_url_or_data_column_is_ignored_at_view_layer():
+    """assign(data=...) writes to _df but is overridden by the store-join
+    in `elements`.
+
+    This pins the current behavior: the load-mechanism layer is the
+    source of truth for url_or_data / encoding, and `assign` cannot
+    override it. If this test starts failing, the API has changed
+    (intentionally or otherwise) and the change should be reviewed.
+    """
+    ds = _trivial_pickle_dataset(3)
+    url_col = ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA
+    ds_with_overwrite = ds.assign(**{url_col: lambda df: ["overwritten"] * 3})
+    # Even though we wrote to _df, the elements view re-synthesizes from
+    # the store, so the original url_or_data values come through.
+    elements_view = ds_with_overwrite.elements
+    assert list(elements_view[url_col]) == ["data-0", "data-1", "data-2"]
+
+
+def test_assign_to_encoding_column_is_ignored_at_view_layer():
+    """Symmetric to the url_or_data case: the encoding column is also
+    re-synthesized from the store and not overridable via `assign`.
+    """
+    ds = _trivial_pickle_dataset(3)
+    enc_col = ELEMENT_COLS.LOAD_MECHANISM.ENCODING
+    ds_with_overwrite = ds.assign(**{enc_col: lambda df: ["bogus"] * 3})
+    elements_view = ds_with_overwrite.elements
+    assert list(elements_view[enc_col]) == ["pickle", "pickle", "pickle"]

--- a/tests/core/test_dataset_construction.py
+++ b/tests/core/test_dataset_construction.py
@@ -39,9 +39,13 @@ def test_extract_store_from_empty_df():
     assert ELEMENT_COLS.LOAD_MECHANISM.ENCODING not in ds._df.columns
 
 
-def test_extract_store_from_df_missing_url_column_no_op():
-    """If URL_OR_DATA column is absent, the store stays empty and the df
-    passes through unchanged (no exception).
+def test_missing_url_column_silent_noop_current_behavior():
+    """Pin the current silent-bail-out when URL_OR_DATA is missing.
+
+    `_extract_store_from_df` returns the input df unchanged with an empty
+    store rather than raising. This is permissive for back-compat, NOT a
+    design invariant — if a future PR adds explicit validation, this test
+    will turn red and force the change to be intentional.
     """
     df = pd.DataFrame(
         {
@@ -60,8 +64,15 @@ def test_extract_store_from_df_missing_url_column_no_op():
     assert ELEMENT_COLS.ETYPE in ds._df.columns
 
 
-def test_extract_store_from_df_missing_encoding_column_no_op():
-    """Symmetric to the previous test: missing ENCODING also bails."""
+def test_missing_encoding_column_silent_noop_current_behavior():
+    """Pin the current silent-bail-out when ENCODING is missing.
+
+    Symmetric to `test_missing_url_column_silent_noop_current_behavior`:
+    `_extract_store_from_df` bails without stripping URL_OR_DATA from the
+    df when ENCODING is absent. This is permissive back-compat behavior,
+    NOT a design invariant — if a future PR adds explicit validation,
+    this test will turn red and force the change to be intentional.
+    """
     df = pd.DataFrame(
         {
             ELEMENT_COLS.ROLE: ["x"],

--- a/tests/core/test_dataset_construction.py
+++ b/tests/core/test_dataset_construction.py
@@ -1,0 +1,144 @@
+"""Edge-case tests for Dataset constructor and _extract_store_from_df back-compat path.
+
+The constructor has two entry-points:
+  * `Dataset(df)` — extracts a fresh ElementStore from the df's url_or_data
+    and encoding columns (back-compat for callers that hand-build a
+    DataFrame).
+  * `Dataset(df, store=...)` — uses the provided store, but still strips
+    any leaked url_or_data / encoding columns from the df.
+
+These edge cases were never explicitly pinned during the v0.2 rewrite.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from bridge.primitives.dataset import Dataset
+from bridge.primitives.element.data.element_store import ElementStore
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.utils.constants import ELEMENT_COLS, INDICES
+
+
+def test_extract_store_from_empty_df():
+    """Empty DataFrame should construct a Dataset with an empty store."""
+    columns = [
+        ELEMENT_COLS.SAMPLE_ID,
+        ELEMENT_COLS.ID,
+        ELEMENT_COLS.ETYPE,
+        ELEMENT_COLS.ROLE,
+        ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA,
+        ELEMENT_COLS.LOAD_MECHANISM.ENCODING,
+    ]
+    df = pd.DataFrame(columns=columns).set_index(INDICES)
+    ds = Dataset(df)
+    assert len(ds) == 0
+    assert isinstance(ds._store, ElementStore)
+    assert len(ds._store) == 0
+    # url_or_data and encoding must be stripped from _df even when empty.
+    assert ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA not in ds._df.columns
+    assert ELEMENT_COLS.LOAD_MECHANISM.ENCODING not in ds._df.columns
+
+
+def test_extract_store_from_df_missing_url_column_no_op():
+    """If URL_OR_DATA column is absent, the store stays empty and the df
+    passes through unchanged (no exception).
+    """
+    df = pd.DataFrame(
+        {
+            ELEMENT_COLS.ROLE: ["x"],
+            ELEMENT_COLS.SAMPLE_ID: [0],
+            ELEMENT_COLS.ID: ["e"],
+            ELEMENT_COLS.ETYPE: ["t"],
+        }
+    ).set_index(INDICES)
+    ds = Dataset(df)
+    # No exception, store is empty.
+    assert isinstance(ds._store, ElementStore)
+    assert len(ds._store) == 0
+    # _df keeps the columns we passed (since the back-compat path bailed early).
+    assert ELEMENT_COLS.ROLE in ds._df.columns
+    assert ELEMENT_COLS.ETYPE in ds._df.columns
+
+
+def test_extract_store_from_df_missing_encoding_column_no_op():
+    """Symmetric to the previous test: missing ENCODING also bails."""
+    df = pd.DataFrame(
+        {
+            ELEMENT_COLS.ROLE: ["x"],
+            ELEMENT_COLS.SAMPLE_ID: [0],
+            ELEMENT_COLS.ID: ["e"],
+            ELEMENT_COLS.ETYPE: ["t"],
+            ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA: ["data"],
+        }
+    ).set_index(INDICES)
+    ds = Dataset(df)
+    assert len(ds._store) == 0
+    # The url_or_data column is preserved on _df because the back-compat
+    # path bailed without stripping (encoding was missing).
+    assert ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA in ds._df.columns
+
+
+def test_dataset_two_arg_construction_with_existing_store():
+    """Dataset(df, store=existing) should not strip the store and should
+    drop any leaked url_or_data / encoding columns from _df.
+    """
+    store = ElementStore()
+    store.set("e1", LoadMechanism("data1", encoding="pickle"))
+    store.set("e2", LoadMechanism("data2", encoding="pickle"))
+
+    df = pd.DataFrame(
+        [
+            {
+                ELEMENT_COLS.SAMPLE_ID: 0,
+                ELEMENT_COLS.ID: "e1",
+                ELEMENT_COLS.ETYPE: "t",
+                ELEMENT_COLS.ROLE: "t",
+            },
+            {
+                ELEMENT_COLS.SAMPLE_ID: 1,
+                ELEMENT_COLS.ID: "e2",
+                ELEMENT_COLS.ETYPE: "t",
+                ELEMENT_COLS.ROLE: "t",
+            },
+        ]
+    ).set_index(INDICES)
+
+    ds = Dataset(df, store=store)
+    assert len(ds) == 2
+    # Store unchanged.
+    assert ds._store.get("e1").url_or_data == "data1"
+    assert ds._store.get("e2").url_or_data == "data2"
+    # Constructor strips URL_OR_DATA / ENCODING from _df even though they
+    # weren't present here — the invariant is "_df never carries those
+    # columns when a store is provided."
+    assert ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA not in ds._df.columns
+    assert ELEMENT_COLS.LOAD_MECHANISM.ENCODING not in ds._df.columns
+
+
+def test_dataset_two_arg_construction_strips_leaked_location_columns():
+    """If a caller passes a df that has url_or_data / encoding columns
+    AND a store, the constructor must strip those columns from _df —
+    the store is the source of truth.
+    """
+    store = ElementStore()
+    store.set("e1", LoadMechanism("authoritative-data", encoding="pickle"))
+
+    df = pd.DataFrame(
+        [
+            {
+                ELEMENT_COLS.SAMPLE_ID: 0,
+                ELEMENT_COLS.ID: "e1",
+                ELEMENT_COLS.ETYPE: "t",
+                ELEMENT_COLS.ROLE: "t",
+                ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA: "stale-data",
+                ELEMENT_COLS.LOAD_MECHANISM.ENCODING: "pickle",
+            },
+        ]
+    ).set_index(INDICES)
+
+    ds = Dataset(df, store=store)
+    assert ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA not in ds._df.columns
+    assert ELEMENT_COLS.LOAD_MECHANISM.ENCODING not in ds._df.columns
+    # The elements view re-synthesizes from the store, so the
+    # authoritative value comes through.
+    assert ds.elements[ELEMENT_COLS.LOAD_MECHANISM.URL_OR_DATA].iloc[0] == "authoritative-data"

--- a/tests/core/test_dataset_merge.py
+++ b/tests/core/test_dataset_merge.py
@@ -1,0 +1,67 @@
+"""Regression test: Dataset.merge combines stores from both sides.
+
+The pre-existing `test_merge_datasets` checks row count but not that the
+merged store contains both sides' load mechanisms. After ElementStore
+landed (sub-branch 3), this is the load-bearing invariant: a merged
+Dataset must be able to resolve every element id from either side
+through `_join_locations` (which reads the store).
+"""
+from __future__ import annotations
+
+from bridge.primitives.dataset import Dataset
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.element import Element
+from bridge.utils.constants import ELEMENT_COLS
+
+
+def _make_pickle_element(eid: str, sample_id, data) -> Element:
+    return Element(
+        element_id=eid,
+        sample_id=sample_id,
+        etype="generic",
+        load_mechanism=LoadMechanism(data, encoding="pickle"),
+    )
+
+
+def test_merge_combines_stores():
+    left_elems = [
+        _make_pickle_element("a", 0, "left-data-a"),
+        _make_pickle_element("b", 1, "left-data-b"),
+    ]
+    right_elems = [
+        _make_pickle_element("c", 2, "right-data-c"),
+        _make_pickle_element("d", 3, "right-data-d"),
+    ]
+
+    left_ds = Dataset.from_role_dict({"generic": left_elems})
+    right_ds = Dataset.from_role_dict({"generic": right_elems})
+
+    merged = left_ds.merge(right_ds)
+
+    assert len(merged) == 4
+    # Every element id from both sides must resolve in the merged store.
+    for eid in ("a", "b", "c", "d"):
+        lm = merged._store.get(eid)
+        assert lm is not None
+        assert lm.encoding == "pickle"
+
+    # And the user-facing elements view should expose all four element ids.
+    user_facing = merged.elements
+    eids_in_view = set(user_facing.index.get_level_values(ELEMENT_COLS.ID))
+    assert eids_in_view == {"a", "b", "c", "d"}
+
+
+def test_merge_preserves_url_or_data_per_side():
+    """The merged store must preserve each side's url_or_data exactly —
+    not pick one side's data for both halves.
+    """
+    left_elems = [_make_pickle_element("a", 0, "left-data-a")]
+    right_elems = [_make_pickle_element("c", 2, "right-data-c")]
+
+    left_ds = Dataset.from_role_dict({"generic": left_elems})
+    right_ds = Dataset.from_role_dict({"generic": right_elems})
+
+    merged = left_ds.merge(right_ds)
+
+    assert merged._store.get("a").url_or_data == "left-data-a"
+    assert merged._store.get("c").url_or_data == "right-data-c"

--- a/tests/core/test_transform_samples_e2e.py
+++ b/tests/core/test_transform_samples_e2e.py
@@ -1,4 +1,8 @@
-"""End-to-end tests for Dataset.transform_samples through the multi-role store path.
+"""Tests for Dataset.transform_samples through the multi-role store path.
+
+Roundtrip through `Dataset._store` and `Dataset.from_elements`. Cache
+mechanisms are accepted but not invoked — the cache-write path is
+covered by `tests/core/test_aliasing_regression.py`.
 
 `Dataset.transform_samples` is the heaviest machinery in the multi-role
 API. Until now it was only smoke-tested via the slow notebook suite.
@@ -21,11 +25,13 @@ from bridge.utils.constants import ELEMENT_COLS
 class _NoOpPickleTransform(SampleTransform):
     """No-op transform that re-emits each element unchanged.
 
-    The element data is loaded once (so the cache-or-not path is
-    exercised), then a fresh Element is constructed pointing at the
-    in-memory data via a pickle-encoded LoadMechanism. The
-    transformed Dataset's elements should compare equal to the
-    originals.
+    Roundtrip through `Dataset._store` and `Dataset.from_elements`. Cache
+    mechanisms are accepted but not invoked — the cache-write path is
+    covered by `tests/core/test_aliasing_regression.py`.
+
+    A fresh Element is constructed pointing at the in-memory data via a
+    pickle-encoded LoadMechanism. The transformed Dataset's elements
+    should compare equal to the originals.
     """
 
     def __call__(
@@ -38,14 +44,12 @@ class _NoOpPickleTransform(SampleTransform):
         for role, elems in sample.elements.items():
             new_elems = []
             for elem in elems:
-                # Force a load so cache machinery (if any) has a chance to fire.
-                data = elem.data
                 new_elems.append(
                     Element(
                         element_id=elem.id,
                         etype=elem.etype,
                         sample_id=elem.sample_id,
-                        load_mechanism=LoadMechanism(data, encoding="pickle"),
+                        load_mechanism=LoadMechanism(elem.data, encoding="pickle"),
                         role=elem.role,
                         metadata=elem.metadata,
                     )

--- a/tests/core/test_transform_samples_e2e.py
+++ b/tests/core/test_transform_samples_e2e.py
@@ -1,0 +1,114 @@
+"""End-to-end tests for Dataset.transform_samples through the multi-role store path.
+
+`Dataset.transform_samples` is the heaviest machinery in the multi-role
+API. Until now it was only smoke-tested via the slow notebook suite.
+This test exercises the round-trip with a trivial pickle-only no-op
+transform, so it stays in tests/core/ and runs without the vision extra.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+from bridge.primitives.dataset import Dataset
+from bridge.primitives.element.data.cache_mechanism import CacheMechanism
+from bridge.primitives.element.data.load_mechanism import LoadMechanism
+from bridge.primitives.element.element import Element
+from bridge.primitives.sample import Sample
+from bridge.primitives.sample.transform.sample_transform import SampleTransform
+from bridge.utils.constants import ELEMENT_COLS
+
+
+class _NoOpPickleTransform(SampleTransform):
+    """No-op transform that re-emits each element unchanged.
+
+    The element data is loaded once (so the cache-or-not path is
+    exercised), then a fresh Element is constructed pointing at the
+    in-memory data via a pickle-encoded LoadMechanism. The
+    transformed Dataset's elements should compare equal to the
+    originals.
+    """
+
+    def __call__(
+        self,
+        sample: Sample,
+        cache_mechanisms: Dict[str, CacheMechanism],
+        display_engine,
+    ) -> Sample:
+        new_elements = {}
+        for role, elems in sample.elements.items():
+            new_elems = []
+            for elem in elems:
+                # Force a load so cache machinery (if any) has a chance to fire.
+                data = elem.data
+                new_elems.append(
+                    Element(
+                        element_id=elem.id,
+                        etype=elem.etype,
+                        sample_id=elem.sample_id,
+                        load_mechanism=LoadMechanism(data, encoding="pickle"),
+                        role=elem.role,
+                        metadata=elem.metadata,
+                    )
+                )
+            new_elements[role] = new_elems
+        return Sample(elements=new_elements, display_engine=display_engine)
+
+
+def _make_dataset_with_two_roles(n_samples: int = 3) -> Dataset:
+    role_a_elems = []
+    role_b_elems = []
+    for i in range(n_samples):
+        role_a_elems.append(
+            Element(
+                element_id=f"a_{i}",
+                sample_id=i,
+                etype="t",
+                load_mechanism=LoadMechanism(f"a-data-{i}", encoding="pickle"),
+            )
+        )
+        role_b_elems.append(
+            Element(
+                element_id=f"b_{i}",
+                sample_id=i,
+                etype="t",
+                load_mechanism=LoadMechanism(f"b-data-{i}", encoding="pickle"),
+            )
+        )
+    return Dataset.from_role_dict({"role_a": role_a_elems, "role_b": role_b_elems})
+
+
+def test_transform_samples_preserves_roles_e2e():
+    ds = _make_dataset_with_two_roles(n_samples=3)
+    transformed = ds.transform_samples(transform=_NoOpPickleTransform())
+
+    assert len(transformed) == 3
+    # Every sample must still have both roles.
+    for sample in transformed:
+        assert "role_a" in sample.elements
+        assert "role_b" in sample.elements
+    # Every element id must resolve in the transformed dataset's store.
+    eids = transformed._df.index.get_level_values(ELEMENT_COLS.ID)
+    for eid in eids:
+        assert transformed._store.get(eid) is not None
+
+
+def test_transform_samples_data_round_trips_through_pickle():
+    ds = _make_dataset_with_two_roles(n_samples=2)
+    transformed = ds.transform_samples(transform=_NoOpPickleTransform())
+    # The no-op transform preserves data byte-for-byte.
+    for original_sample, new_sample in zip(ds, transformed):
+        for role in ("role_a", "role_b"):
+            assert original_sample.one(role).data == new_sample.one(role).data
+
+
+def test_transform_samples_roundtrips_element_ids():
+    """Element ids must survive the round-trip — the no-op transform
+    constructs new Elements with the same ids, and Dataset.from_elements
+    builds a fresh store keyed by those ids.
+    """
+    ds = _make_dataset_with_two_roles(n_samples=3)
+    transformed = ds.transform_samples(transform=_NoOpPickleTransform())
+
+    original_eids = set(ds._df.index.get_level_values(ELEMENT_COLS.ID))
+    new_eids = set(transformed._df.index.get_level_values(ELEMENT_COLS.ID))
+    assert original_eids == new_eids

--- a/tests/vision/test_providers.py
+++ b/tests/vision/test_providers.py
@@ -15,6 +15,7 @@ from PIL import Image
 
 from bridge.providers.text import LargeMovieReviewDataset
 from bridge.providers.vision import ImageFolder
+from bridge.utils.constants import ELEMENT_COLS
 
 
 def _write_jpeg(path: Path, h: int = 32, w: int = 32) -> None:
@@ -76,6 +77,19 @@ def test_imagefolder_class_labels_distinct(imagefolder_root):
         class_indices.add(cl.class_idx)
 
     assert class_indices == {0, 1}
+
+
+def test_imagefolder_element_ids_are_unique(imagefolder_root):
+    """ImageFolder must mint unique element_ids across all samples and classes.
+
+    A latent bug — two classes producing duplicate element_ids like
+    `class_{i}` — was previously caught structurally by ElementStore.set's
+    strict-on-duplicate raise. Pin the invariant explicitly so intent is
+    documented even if ElementStore ever loosens that check.
+    """
+    ds = ImageFolder(imagefolder_root).build_dataset()
+    eids = ds.elements.index.get_level_values(ELEMENT_COLS.ID)
+    assert len(set(eids)) == len(eids)
 
 
 def test_imagefolder_image_data_loadable(imagefolder_root):

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -285,6 +286,7 @@ requires-dist = [
     { name = "scikit-image", marker = "extra == 'vision'", specifier = ">=0.21" },
     { name = "tabulate", marker = "extra == 'vision'", specifier = ">=0.9" },
     { name = "tqdm", specifier = ">=4.60" },
+    { name = "typing-extensions", specifier = ">=4.0" },
 ]
 provides-extras = ["vision"]
 


### PR DESCRIPTION
## Summary
Final v0.2 sub-branch. Closes test gaps that landed during the v0.2 rewrite without explicit coverage; adds a one-shot safety net for the cross-matrix bug class we hit during element-store work.

- `scripts/check_core_no_extras.sh` runs `tests/core` in a fresh no-extras venv. Surfaces tests that accidentally pull in vision-extra deps (we hit this once when a JPEG cache write lazy-imported skimage on CI core).
- `CONTRIBUTING.md` documents the rule: tests/core uses only core encodings (`pickle`, `utf8`, `npy`).
- Pinned cross-cutting invariants:
  - `Dataset.merge` combines both sides' load-mechanism stores
  - `Dataset` constructor edge cases (empty df, two-arg with existing store, missing-column permissive bail-out — pinned as "current behavior", not "design invariant")
  - `transform_samples` end-to-end roundtrip through the multi-role store path (pickle-only, no vision deps)
  - `ImageFolder` element_id uniqueness invariant
  - `Dataset.assign(data=...)` no-propagate semantics (pinned as current behavior; future API changes are forced to be intentional)

## Side effect
Adding the no-extras hook surfaced an implicit dependency: `bridge` imports `typing_extensions.Self` at module-import time but didn't declare it. Added `typing_extensions>=4.0` to runtime `dependencies`. (Could alternately be replaced with `typing.Self` since the project requires Python ≥3.11 — left for a follow-up cleanup.)

## Test plan
- [x] All new tests green (152 unit + 9 slow notebook = 161 total)
- [x] `bash scripts/check_core_no_extras.sh` succeeds (101 tests in no-extras venv)
- [x] Both review-stage docstring clarifications applied (transform_samples_e2e + construction tests)